### PR TITLE
generate add partition statement in batches

### DIFF
--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -69,7 +69,7 @@
     
     {%- set ddl -%}
 
-    {{ add_partitions(
+    {{ redshift__alter_table_add_partitions(
         source.database ~ "." ~ source.schema ~ "." ~ source.identifier,
         source.external.location,
         finals

--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -68,13 +68,14 @@
     {%- endfor -%}{%- endif -%}
     
     {%- set ddl -%}
-    {%- for final in finals %}
-    
-        alter table {{source.database}}.{{source.schema}}.{{source.identifier}}
-            add partition ({%- for part in final.partition_by -%}{{part.name}}='{{part.value}}'{{',' if not loop.last}}{%- endfor -%}) 
-            location '{{source.external.location}}{{final.path}}/' {{- ';' if not loop.last -}}
-    
-    {% endfor -%}
+
+    {{ add_partitions(
+        source.database ~ "." ~ source.schema ~ "." ~ source.identifier,
+        source.external.location,
+        finals
+      )
+    }}
+
     {%- endset -%}
     
     {{return(ddl)}}

--- a/macros/helpers.sql
+++ b/macros/helpers.sql
@@ -44,7 +44,7 @@
   to generate multiple altes when the number of partitions to add exceeds 100.
 
   Arguments:
-    - table (string): The name of the table to generate the partitions for.
+    - source (string): The name of the table to generate the partitions for.
     - source_external_location (string): Base location of the external table. Paths
         in the 'partitions' argument are specified relative to this location.
     - partitions (list): A list of partitions to be added to the external table.
@@ -56,20 +56,20 @@
           - path (string): The path to be added as a partition for the particular
               combination of columns defined in the 'partition_by'
 #}
-{% macro add_partitions(table, source_external_location, partitions) %}
+{% macro redshift__alter_table_add_partitions(source, source_external_location, partitions) %}
 
   {{ log("Generating ADD PARTITION statement for partition set \n" ~ partitions, info=True) }}
 
   {% if partitions|length > 0 %}
 
-      alter table {{ table }} add
+      alter table {{ source }} add
 
     {% for partition in partitions %}
 
-      {% if loop.index % 100 == 0 %}
+      {% if loop.index0 != 0 and loop.index0 % 100 == 0 %}
 
         ; -- close alter statement and open a new one
-        alter table {{ table }} add
+        alter table {{ source }} add
 
       {% endif %}
 

--- a/macros/helpers.sql
+++ b/macros/helpers.sql
@@ -36,3 +36,52 @@
     {{return(ddl)}}
 
 {% endmacro %}
+
+{#
+  Generates a series of alter statements to add a batch of partitions to a table.
+  Ideally it would require a single alter statement to add all partitions, but
+  Amazon imposes a limit of 100 partitions per alter statement. Therefore we need
+  to generate multiple altes when the number of partitions to add exceeds 100.
+
+  Arguments:
+    - table (string): The name of the table to generate the partitions for.
+    - source_external_location (string): Base location of the external table. Paths
+        in the 'partitions' argument are specified relative to this location.
+    - partitions (list): A list of partitions to be added to the external table.
+        Each partition is represented by a dictionary with the keys:
+          - partition_by (list): A set of columns that the partition is affected by
+              Each column is represented by a dictionary with the keys:
+                - name: Name of the column
+                - value: Value of the column
+          - path (string): The path to be added as a partition for the particular
+              combination of columns defined in the 'partition_by'
+#}
+{% macro add_partitions(table, source_external_location, partitions) %}
+
+  {{ log("Generating ADD PARTITION statement for partition set \n" ~ partitions, info=True) }}
+
+  {% if partitions|length > 0 %}
+
+      alter table {{ table }} add
+
+    {% for partition in partitions %}
+
+      {% if loop.index % 100 == 0 %}
+
+        ; -- close alter statement and open a new one
+        alter table {{ table }} add
+
+      {% endif %}
+
+        partition ({%- for part in partition.partition_by -%}{{ part.name }}='{{ part.value }}'{{',' if not loop.last}}{%- endfor -%})
+        location '{{ source_external_location }}{{ partition.path }}/'
+
+    {% endfor %}
+
+  {% else %}
+
+    {{ log("No partitions to be added", info=True) }}
+
+  {% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
Generates `ADD PARTITION` statements in batches for a more performant `stage_external_sources`.

From [AWS docs](https://docs.aws.amazon.com/redshift/latest/dg/c-spectrum-external-tables.html#c-spectrum-external-tables-partitioning), the `ADD PARTITION` statement on an external partitioned table supports adding up to 100 partitions per statement. The new `add_partitions` macro exploits this.

Closes #2 

