### PR TITLE
Refactor: smarter dropif, prettified logging

### DIFF
--- a/macros/external/create_external_table.sql
+++ b/macros/external/create_external_table.sql
@@ -40,7 +40,7 @@
     {%- set partitions = external.partition -%}
 
 {# https://spark.apache.org/docs/latest/sql-data-sources-hive-tables.html #}
-    create external table {{source.database}}.{{source.schema}}.{{source.identifier}} (
+    create external table {{source(source.source_name, source.name)}} (
         {% for column in columns %}
             {{column.name}} {{column.data_type}}
             {{- ',' if not loop.last -}}
@@ -65,7 +65,7 @@
 
 {# https://docs.snowflake.net/manuals/sql-reference/sql/create-external-table.html #}
 {# This assumes you have already created an external stage #}
-    create or replace external table {{source.database}}.{{source.schema}}.{{source.identifier}} (
+    create or replace external table {{source(source.source_name, source.name)}} (
         {%- if partitions -%}{%- for partition in partitions %}
             {{partition.name}} {{partition.data_type}} as {{partition.expression}},
         {%- endfor -%}{%- endif -%}

--- a/macros/external/create_external_table.sql
+++ b/macros/external/create_external_table.sql
@@ -64,7 +64,7 @@
 
 {# https://docs.snowflake.net/manuals/sql-reference/sql/create-external-table.html #}
 {# This assumes you have already created an external stage #}
-    create external table {{source.database}}.{{source.schema}}.{{source.identifier}} (
+    create or replace external table {{source.database}}.{{source.schema}}.{{source.identifier}} (
         {%- if partitions -%}{%- for partition in partitions %}
             {{partition.name}} {{partition.data_type}} as {{partition.expression}},
         {%- endfor -%}{%- endif -%}

--- a/macros/external/create_external_table.sql
+++ b/macros/external/create_external_table.sql
@@ -8,15 +8,15 @@
 
 {% macro redshift__create_external_table(source) %}
 
-    {% set columns = source.columns %}
-    {% set external = source.external %}
-    {% set partitions = external.partitions %}
+    {%- set columns = source.columns.values() -%}
+    {%- set external = source.external -%}
+    {%- set partitions = external.partitions -%}
 
 {# https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_TABLE.html #}
 {# This assumes you have already created an external schema #}
 
     create external table {{source.database}}.{{source.schema}}.{{source.name}} (
-        {% for column in columns.values() %}
+        {% for column in columns %}
             {{adapter.quote(column.name)}} {{column.data_type}}
             {{- ',' if not loop.last -}}
         {% endfor %}
@@ -35,13 +35,13 @@
 
 {% macro spark__create_external_table(source) %}
 
-    {% set columns = source.columns %}
-    {% set external = source.external %}
-    {% set partitions = external.partition %}
+    {%- set columns = source.columns.values() -%}
+    {%- set external = source.external -%}
+    {%- set partitions = external.partition -%}
 
 {# https://spark.apache.org/docs/latest/sql-data-sources-hive-tables.html #}
     create external table {{source.database}}.{{source.schema}}.{{source.identifier}} (
-        {% for column in source.columns.values() %}
+        {% for column in columns %}
             {{column.name}} {{column.data_type}}
             {{- ',' if not loop.last -}}
         {% endfor %}
@@ -59,6 +59,7 @@
 
 {% macro snowflake__create_external_table(source) %}
 
+    {%- set columns = source.columns.values() -%}
     {%- set external = source.external -%}
     {%- set partitions = external.partitions -%}
 
@@ -68,7 +69,7 @@
         {%- if partitions -%}{%- for partition in partitions %}
             {{partition.name}} {{partition.data_type}} as {{partition.expression}},
         {%- endfor -%}{%- endif -%}
-        {% for column in source.columns.values() %}
+        {% for column in columns %}
             {{column.name}} {{column.data_type}} as (nullif(value:{{column.name}},'')::{{column.data_type}})
             {{- ',' if not loop.last -}}
         {% endfor %}

--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -30,7 +30,7 @@
         {%- for preexisting in starting -%}
             
             {%- if partition.vals.macro -%}
-                {%- set vals = render_from_context(partition.vals.macro, **partition.vals.args) -%}
+                {%- set vals = dbt_external_tables.render_from_context(partition.vals.macro, **partition.vals.args) -%}
             {%- elif partition.vals is string -%}
                 {%- set vals = [partition.vals] -%}
             {%- else -%}
@@ -51,7 +51,7 @@
 
                 {# Concatenate path #}
 
-                {%- set concat_path = preexisting.path ~ '/' ~ render_from_context(partition.path_macro, partition.name, val) -%}
+                {%- set concat_path = preexisting.path ~ '/' ~ dbt_external_tables.render_from_context(partition.path_macro, partition.name, val) -%}
                 
                 {%- do ending.append({'partition_by': next_partition_by, 'path': concat_path}) -%}
             
@@ -69,7 +69,7 @@
     
     {%- set ddl -%}
 
-    {{ redshift__alter_table_add_partitions(
+    {{ dbt_external_tables.redshift__alter_table_add_partitions(
         source.database ~ "." ~ source.schema ~ "." ~ source.identifier,
         source.external.location,
         finals

--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -82,12 +82,6 @@
     
 {% endmacro %}
 
-{% macro spark__refresh_external_table(source) %}
-
-    {{return('-- noop')}}
-
-{% endmacro %}
-
 {% macro snowflake__refresh_external_table(source) %}
 
     {% set alter %}

--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -85,7 +85,7 @@
 {% macro snowflake__refresh_external_table(source) %}
 
     {% set alter %}
-    alter external table {{source.database}}.{{source.schema}}.{{source.identifier}} refresh
+    alter external table {{source(source.source_name, source.name)}} refresh
     {% endset %}
     
     {{return(alter)}}

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -4,10 +4,14 @@
         
         {% if node.resource_type == 'source' and node.external != none %}
             
-            {%- set run_queue = [
-                dropif(node),
-                create_external_table(node)
-            ] -%}
+            {%- set run_queue = [] -%}
+            
+            {%- if target.type != 'snowflake' -%}
+                {# Snowflake supports "create or replace" #}
+                {%- do run_queue.append(dropif(node))  -%}
+            {%- endif -%}
+            
+            {%- do run_queue.append(create_external_table(node)) -%}
             
             {%- if node.external.partitions -%}
                 {%- set run_queue = run_queue + refresh_external_table(node).split(';') -%}

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -3,6 +3,8 @@
     {% for node in graph.nodes.values() %}
         
         {% if node.resource_type == 'source' and node.external != none %}
+        
+            {%- do log('Staging external table ' ~ node.source_name ~ '.' ~ node.name, info = true) -%}
             
             {%- set run_queue = [] -%}
             
@@ -24,7 +26,9 @@
                 {% endcall %}
                 
                 {% set status = load_result('runner')['status'] %}
-                {% do log(loop.index ~ '. ' ~ status, info = true) %}
+                {% set ts = modules.datetime.datetime.now().strftime('%H:%M:%S') %}
+                {% set msg = ts ~ ' + (' ~ loop.index ~ ') ' ~ status %}
+                {% do log(msg, info = true) %}
                 
             {% endfor %}
             

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -15,7 +15,7 @@
             
             {%- do run_queue.append(create_external_table(node)) -%}
             
-            {%- if node.external.partitions -%}
+            {%- if node.external.partitions and target.type != 'spark' -%}
                 {%- set run_queue = run_queue + refresh_external_table(node).split(';') -%}
             {%- endif -%}
             

--- a/macros/helpers.sql
+++ b/macros/helpers.sql
@@ -54,7 +54,7 @@
 #}
 {% macro redshift__alter_table_add_partitions(source, source_external_location, partitions) %}
 
-  {{ log("Generating ADD PARTITION statement for partition set \n" ~ partitions, info=True) }}
+  {{ log("Generating ADD PARTITION statement for partition set \n" ~ partitions) }}
 
   {% if partitions|length > 0 %}
 

--- a/macros/helpers.sql
+++ b/macros/helpers.sql
@@ -24,13 +24,9 @@
 {% macro dropif(node) %}
 
     {% set fqn = [node.database, node.schema, node.identifier]|join('.') %}
-    {# snowflake returns 'externaltable' as relation type,
-    which should be 'external table' for dropping,
-    this is part of BaseRelation def #}
-    {% set reltype = 'external table' if target.type == 'snowflake' else 'table' %}
     
     {% set ddl %}
-        drop {{reltype}} if exists {{fqn}} cascade
+        drop table if exists {{fqn}} cascade
     {% endset %}
     
     {{return(ddl)}}

--- a/macros/helpers/common.sql
+++ b/macros/helpers/common.sql
@@ -1,0 +1,34 @@
+{% macro render_from_context(name) -%}
+{% set original_name = name %}
+  {% if '.' in name %}
+    {% set package_name, name = name.split(".", 1) %}
+  {% else %}
+    {% set package_name = none %}
+  {% endif %}
+
+  {% if package_name is none %}
+    {% set package_context = context %}
+  {% elif package_name in context %}
+    {% set package_context = context[package_name] %}
+  {% else %}
+    {% set error_msg %}
+        In adapter_macro: could not find package '{{package_name}}', called with '{{original_name}}'
+    {% endset %}
+    {{ exceptions.raise_compiler_error(error_msg | trim) }}
+  {% endif %}
+  
+    {{ return(package_context[name](*varargs, **kwargs)) }}
+
+{%- endmacro %}
+
+{% macro dropif(node) %}
+
+    {% set fqn = [node.database, node.schema, node.identifier]|join('.') %}
+    
+    {% set ddl %}
+        drop table if exists {{fqn}} cascade
+    {% endset %}
+    
+    {{return(ddl)}}
+
+{% endmacro %}

--- a/macros/helpers/redshift/add_partitions.sql
+++ b/macros/helpers/redshift/add_partitions.sql
@@ -1,37 +1,3 @@
-{% macro render_from_context(name) -%}
-{% set original_name = name %}
-  {% if '.' in name %}
-    {% set package_name, name = name.split(".", 1) %}
-  {% else %}
-    {% set package_name = none %}
-  {% endif %}
-
-  {% if package_name is none %}
-    {% set package_context = context %}
-  {% elif package_name in context %}
-    {% set package_context = context[package_name] %}
-  {% else %}
-    {% set error_msg %}
-        In adapter_macro: could not find package '{{package_name}}', called with '{{original_name}}'
-    {% endset %}
-    {{ exceptions.raise_compiler_error(error_msg | trim) }}
-  {% endif %}
-  
-    {{ return(package_context[name](*varargs, **kwargs)) }}
-
-{%- endmacro %}
-
-{% macro dropif(node) %}
-
-    {% set fqn = [node.database, node.schema, node.identifier]|join('.') %}
-    
-    {% set ddl %}
-        drop table if exists {{fqn}} cascade
-    {% endset %}
-    
-    {{return(ddl)}}
-
-{% endmacro %}
 
 {#
   Generates a series of alter statements to add a batch of partitions to a table.

--- a/macros/helpers/redshift/paths.sql
+++ b/macros/helpers/redshift/paths.sql
@@ -1,0 +1,9 @@
+{% macro year_month_day(name, value) %}
+    {% set path = value.replace('-','/') %}
+    {{return(path)}}
+{% endmacro %}
+
+{% macro key_value(name, value) %}
+    {% set path = name ~ '=' ~ value %}
+    {{return(path)}}
+{% endmacro %}

--- a/sample_sources/redshift.yml
+++ b/sample_sources/redshift.yml
@@ -25,7 +25,7 @@ sources:
                   end_date_str: '{{modules.datetime.date.today().strftime("%Y-%m-%d")}}'
                   in_fmt: "%Y-%m-%d"
                   out_fmt: "%Y-%m-%d"
-              path_macro: test_external_sources_redshift.year_month_day
+              path_macro: dbt_external_tables.year_month_day
         columns:
           - name: app_id
             data_type: varchar(255)


### PR DESCRIPTION
Getting ready to cut the `0.1.0` release of this package, now that there's a release candidate for dbt `0.15.0`.

### Changelog
* Prettier logging with timestamps, based on [dbt-utils](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/logger/pretty_log_format.sql). Remove stdout logging of Redshift partition creation, but keep debug output.
* Snowflake now supports `create or replace` for external tables, so we remove the `drop` step (and the added complexity of Snowflake's bespoke `external table` relation type).
* Fixes #5 by adding more helper macros. Reorganizes existing ones.
* Other misc cleanup for consistency across adapter macros.