### PR TITLE
Fix check for non-external sources

### DIFF
--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -2,7 +2,7 @@
     
     {% for node in graph.nodes.values() %}
         
-        {% if node.resource_type == 'source' and node.external != none %}
+        {% if node.resource_type == 'source' and node.external.location != none %}
             
             {%- set run_queue = [
                 dropif(node),


### PR DESCRIPTION
### Bugfix

Checking `source.external` for a `source` missing an `external` object still returns
```
{'location': None, 'file_format': None, 'row_format': None, 'tbl_properties': None, 'partitions': None}
```
Instead, we should check that `node.external.location != none` before continuing, so as to ensure that we don't accidentally drop a non-external source.

### Comment

Thanks to Marton Hubay in dbt Slack for finding this bug.

For safety, the Redshift/Snowflake user running dbt should _not_ have permissions to drop any sources it is not responsible for staging, i.e. all sources except external tables.