### PR TITLE
Fix: change arg name to unmask source()

### DIFF
--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -1,12 +1,12 @@
-{% macro refresh_external_table(source) %}
-    {{ adapter_macro('refresh_external_table', source) }}
+{% macro refresh_external_table(source_node) %}
+    {{ adapter_macro('refresh_external_table', source_node) }}
 {% endmacro %}
 
-{% macro default__refresh_external_table(source) %}
+{% macro default__refresh_external_table(source_node) %}
     {{ exceptions.raise_compiler_error("External table creation is not implemented for the default adapter") }}
 {% endmacro %}
 
-{% macro redshift__refresh_external_table(source) %}
+{% macro redshift__refresh_external_table(source_node) %}
 
     {%- set starting = [
         {
@@ -18,7 +18,7 @@
     {%- set ending = [] -%}
     {%- set finals = [] -%}
     
-    {%- set partitions = source.external.get('partitions',[]) -%}
+    {%- set partitions = source_node.external.get('partitions',[]) -%}
 
     {%- if partitions -%}{%- for partition in partitions -%}
     
@@ -70,8 +70,7 @@
     {%- set ddl -%}
 
     {{ dbt_external_tables.redshift__alter_table_add_partitions(
-        source.database ~ "." ~ source.schema ~ "." ~ source.identifier,
-        source.external.location,
+        source_node,
         finals
       )
     }}
@@ -82,23 +81,23 @@
     
 {% endmacro %}
 
-{% macro snowflake__refresh_external_table(source) %}
+{% macro snowflake__refresh_external_table(source_node) %}
 
     {% set alter %}
-    alter external table {{source(source.source_name, source.name)}} refresh
+    alter external table {{source(source_node.source_name, source_node.name)}} refresh
     {% endset %}
     
     {{return(alter)}}
     
 {% endmacro %}
 
-{% macro bigquery__refresh_external_table(source) %}
+{% macro bigquery__refresh_external_table(source_node) %}
     {{ exceptions.raise_compiler_error(
         "BigQuery does not support creating external tables in SQL/DDL. 
         Create it from the BQ console.") }}
 {% endmacro %}
 
-{% macro presto__refresh_external_table(source) %}
+{% macro presto__refresh_external_table(source_node) %}
     {{ exceptions.raise_compiler_error(
         "Presto does not support creating external tables with 
         the Hive connector. Do so from Hive directly.") }}

--- a/macros/helpers/redshift/add_partitions.sql
+++ b/macros/helpers/redshift/add_partitions.sql
@@ -18,25 +18,25 @@
           - path (string): The path to be added as a partition for the particular
               combination of columns defined in the 'partition_by'
 #}
-{% macro redshift__alter_table_add_partitions(source, source_external_location, partitions) %}
+{% macro redshift__alter_table_add_partitions(source_node, partitions) %}
 
   {{ log("Generating ADD PARTITION statement for partition set \n" ~ partitions) }}
 
   {% if partitions|length > 0 %}
 
-      alter table {{ source }} add
+      alter table {{source(source_node.source_name, source_node.name)}} add
 
     {% for partition in partitions %}
 
       {% if loop.index0 != 0 and loop.index0 % 100 == 0 %}
 
         ; -- close alter statement and open a new one
-        alter table {{ source }} add
+        alter table {{source(source_node.source_name, source_node.name)}} add
 
       {% endif %}
 
         partition ({%- for part in partition.partition_by -%}{{ part.name }}='{{ part.value }}'{{',' if not loop.last}}{%- endfor -%})
-        location '{{ source_external_location }}{{ partition.path }}/'
+        location '{{ source_node.external.location }}{{ partition.path }}/'
 
     {% endfor %}
 


### PR DESCRIPTION
Fixes #7

### Changelog

* Rename arg in `create_external_table` and `refresh_external_table` to `source_node` so that it doesn't mask `'dbt.context.runtime.SourceResolver object'`, i.e. the `{{ source() }}` function that we know and love since 0.13.0.

### Acceptance criteria

* I tested locally on both Redshift and Snowflake. I should've tested on both before merging #4, which switched this behavior on Snowflake but not on Redshift. This PR returns both to functional consistency.