### PR TITLE
Fix: Snowflake CSVs

### DIFF
--- a/macros/external/create_external_table.sql
+++ b/macros/external/create_external_table.sql
@@ -62,6 +62,8 @@
     {%- set columns = source_node.columns.values() -%}
     {%- set external = source_node.external -%}
     {%- set partitions = external.partitions -%}
+    
+    {%- set is_csv = is_csv(external.file_format) -%}
 
 {# https://docs.snowflake.net/manuals/sql-reference/sql/create-external-table.html #}
 {# This assumes you have already created an external stage #}
@@ -70,7 +72,14 @@
             {{partition.name}} {{partition.data_type}} as {{partition.expression}},
         {%- endfor -%}{%- endif -%}
         {% for column in columns %}
-            {{column.name}} {{column.data_type}} as (nullif(value:{{column.name}},'')::{{column.data_type}})
+            {%- set col_expression -%}
+                {%- if is_csv -%}{# special case: get columns by ordinal position #}
+                    nullif(value:c{{loop.index}},'')
+                {%- else -%}{# standard behavior: get columns by name #}
+                    nullif(value:{{column.name}},'')
+                {%- endif -%}
+            {%- endset -%}
+            {{column.name}} {{column.data_type}} as ({{col_expression}}::{{column.data_type}})
             {{- ',' if not loop.last -}}
         {% endfor %}
     )

--- a/macros/external/create_external_table.sql
+++ b/macros/external/create_external_table.sql
@@ -71,14 +71,12 @@
         {%- if partitions -%}{%- for partition in partitions %}
             {{partition.name}} {{partition.data_type}} as {{partition.expression}},
         {%- endfor -%}{%- endif -%}
-        {% for column in columns %}
+        {%- for column in columns %}
             {%- set col_expression -%}
-                {%- if is_csv -%}{# special case: get columns by ordinal position #}
-                    nullif(value:c{{loop.index}},'')
-                {%- else -%}{# standard behavior: get columns by name #}
-                    nullif(value:{{column.name}},'')
+                {%- if is_csv -%}nullif(value:c{{loop.index}},''){# special case: get columns by ordinal position #}
+                {%- else -%}nullif(value:{{column.name}},''){# standard behavior: get columns by name #}
                 {%- endif -%}
-            {%- endset -%}
+            {%- endset %}
             {{column.name}} {{column.data_type}} as ({{col_expression}}::{{column.data_type}})
             {{- ',' if not loop.last -}}
         {% endfor %}

--- a/macros/external/create_external_table.sql
+++ b/macros/external/create_external_table.sql
@@ -63,7 +63,7 @@
     {%- set external = source_node.external -%}
     {%- set partitions = external.partitions -%}
     
-    {%- set is_csv = is_csv(external.file_format) -%}
+    {%- set is_csv = dbt_external_tables.is_csv(external.file_format) -%}
 
 {# https://docs.snowflake.net/manuals/sql-reference/sql/create-external-table.html #}
 {# This assumes you have already created an external stage #}

--- a/macros/helpers/snowflake/is_csv.sql
+++ b/macros/helpers/snowflake/is_csv.sql
@@ -11,14 +11,26 @@ you should only specify one or the other when creating an external table.
 
 #}
 
-    {% if 'format_name' in file_format %}
+    {% set ff_ltrimmed = file_format|lower|replace(' ','') %}
+
+    {% if 'type=' in ff_ltrimmed %}
     
-        {% set ff_standardized = file_format|lower
-            | replace('(','') | replace(')','') | replace(' ','')
+        {% if 'type=csv' in ff_ltrimmed %}
+
+            {{return(true)}}
+
+        {% else %}
+
+            {{return(false)}}
+            
+        {% endif %}
+        
+    {% else %}
+    
+        {% set ff_standardized = ff_ltrimmed
+            | replace('(','') | replace(')','')
             | replace('format_name=','') %}
         {% set fqn = ff_standardized.split('.') %}
-        
-        {% do log(format_fqn, info = true) %}
         
         {% if fqn | length == 3 %}
             {% set ff_database, ff_schema, ff_identifier = fqn[0], fqn[1], fqn[2] %}
@@ -44,21 +56,7 @@ you should only specify one or the other when creating an external table.
         
         {% endfor %}
         
-        {{return(false)}}
-            
-    {% else %}
-
-        {% set ff_standardized = file_format|lower|replace(' ','') %}
-        
-        {% if 'type=csv' in ff_standardized %}
-
-            {{return(true)}}
-
-        {% else %}
-    
-            {{return(false)}}
-            
-        {% endif %}
+        {{return(false)}}        
     
     {% endif %}
 

--- a/macros/helpers/snowflake/is_csv.sql
+++ b/macros/helpers/snowflake/is_csv.sql
@@ -1,0 +1,50 @@
+{% macro is_csv(file_format) %}
+
+{# From https://docs.snowflake.net/manuals/sql-reference/sql/create-external-table.html:
+
+Important: The external table does not inherit the file format, if any, in the 
+stage definition. You must explicitly specify any file format options for the 
+external table using the FILE_FORMAT parameter.
+
+Note: FORMAT_NAME and TYPE are mutually exclusive; to avoid unintended behavior, 
+you should only specify one or the other when creating an external table.
+
+#}
+
+    {% if 'format_name' in file_format %}
+    
+        {% set file_format_identifier = file_format.split('.')|last %}
+    
+        {% call statement('get_file_format', fetch_results = True) %}
+            show file formats like '{{file_format.split()}}'
+        {% endcall %}
+        
+        {% set ff_type = load_result('get_file_format').table.columns['TYPE'] %}
+        
+        {% if ff_type == 'csv' %}
+        
+            {{return(true)}}
+            
+        {% else %}
+        
+            {{return(false)}}
+            
+        {% endif %}
+            
+    {% else %}
+
+        {% set ff_standardized = file_format|lowercase|replace(' ','') %}
+        
+        {% if 'type=csv' in ff_standardized %}
+
+            {{return(true)}}
+
+        {% else %}
+    
+            {{return(false)}}
+            
+        {% endif %}
+    
+    {% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
Attempt resolution of #12 

* Create `is_csv()` macro to identify whether a Snowflake external table is staging CSV files
* If staging CSVs, use the `value:c1, value:c2, ...` syntax to define columns in `snowflake__create_external_table`

The `is_csv()` functionality checks to see if either:
* The `file_format` contains the word `format_name`, in which case it will attempt to parse the named file format and check to see if its `type` is `csv`.
* The `file_format` itself contains `'type=csv'` (after lowercasing + trimming whitespace)