### PR TITLE
add single quoting around pattern for snowflake create external table ddl

### DIFF
--- a/macros/external/create_external_table.sql
+++ b/macros/external/create_external_table.sql
@@ -84,7 +84,7 @@
     {% if partitions -%} partition by ({{partitions|map(attribute='name')|join(', ')}}) {%- endif %}
     location = {{external.location}} {# stage #}
     {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
-    {% if external.pattern -%} pattern = {{external.pattern}} {%- endif %}
+    {% if external.pattern -%} pattern = '{{external.pattern}}' {%- endif %}
     file_format = {{external.file_format}}
 {% endmacro %}
 


### PR DESCRIPTION
This PR adds single quotes around the pattern definition in the create external table macro for snowflake.