### PR TITLE
Use schema.identifier for log info out

### DIFF
--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -5,7 +5,7 @@
         {% if node.resource_type == 'source' and node.external.location != none %}
         
             {% set ts = modules.datetime.datetime.now().strftime('%H:%M:%S') %}
-            {%- do log(ts ~ ' + Staging external table ' ~ node.source_name ~ '.' ~ node.name, info = true) -%}
+            {%- do log(ts ~ ' + Staging external table ' ~ node.schema ~ '.' ~ node.identifier, info = true) -%}
             
             {%- set run_queue = [] -%}
             


### PR DESCRIPTION
As of 0.16.0, it's possible to use Jinja in YML configuration of `sources`. For example:
```yml
sources:
  - name: spectrum
    schema: "{{ target.schema ~ if target.name == 'dev' else 'spectrum' }}"

    tables:

      - name: my_special_name
        identifier: my_actual_table_name
        external: ...
```

In all environments, `stage_external_sources` macro currently prints out `source_name` + `name`:
```bash
17:09:21 + Staging external table spectrum.my_special_name
17:09:24 + (1) DROP TABLE
17:09:33 + (2) CREATE EXTERNAL TABLE
```

Instead, it should print out `schema` + `identifier`, such that running in development will look like:
```bash
17:09:21 + Staging external table dbt_jcohen_spectrum.my_actual_table_name
17:09:24 + (1) DROP TABLE
17:09:33 + (2) CREATE EXTERNAL TABLE
```