### PR TITLE
Feature/external source node selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 ### External tables in dbt
 
 * Source config extension for metadata about external file structure
-* Adapter macros to create and "refresh" partitioned external tables
+* Adapter macros to create external tables and refresh external table partitions
+* Snowflake-specific macros to create, backfill, and refresh snowpipes
 
 ```bash
-# iterate through all source nodes, run drop + create + refresh (if partitioned)
+# iterate through all source nodes, create if missing + refresh if appropriate
 dbt run-operation stage_external_sources
 
-# maybe someday: dbt source stage-external
+# iterate through all source nodes, create or replace + refresh if appropriate
+dbt run-operation stage_external_sources --vars 'ext_full_refresh: true'
+# maybe someday: dbt source stage-external --full-refresh
 ```
 
 ![sample docs](etc/sample_docs.png)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ and create tables in it.
 ### Spec
 
 ```yml
-source:
+version: 2
+
+sources:
   - name: snowplow
     tables:
       - name: event
@@ -30,6 +32,7 @@ source:
           file_format:      # Hive specification or Snowflake named format / specification
           row_format:       # Hive specification
           tbl_properties:   # Hive specification
+          snowpipe:         # Snowflake: create an empty table + pipe instead of an external table
           
                             # Specify a list of file-path partitions.
           

--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ sources:
           file_format:      # Hive specification or Snowflake named format / specification
           row_format:       # Hive specification
           tbl_properties:   # Hive specification
-          snowpipe:         # Snowflake: create an empty table + pipe instead of an external table
+          
+          # Snowflake: create an empty table + pipe instead of an external table
+          snowpipe:
+            auto_ingest:    # true or false
+            aws_sns_topic:  # AWS
+            integration:    # Azure
           
                             # Specify a list of file-path partitions.
           

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@
 
 ```bash
 # iterate through all source nodes, create if missing + refresh if appropriate
-dbt run-operation stage_external_sources
+$ dbt run-operation stage_external_sources
 
 # iterate through all source nodes, create or replace + refresh if appropriate
-dbt run-operation stage_external_sources --vars 'ext_full_refresh: true'
-# maybe someday: dbt source stage-external --full-refresh
+$ dbt run-operation stage_external_sources --vars 'ext_full_refresh: true'
 ```
 
 ![sample docs](etc/sample_docs.png)
@@ -18,6 +17,24 @@ dbt run-operation stage_external_sources --vars 'ext_full_refresh: true'
 The macros assume that you have already created an external stage (Snowflake)
 or external schema (Spectrum), and that you have permissions to select from it
 and create tables in it.
+
+The `stage_external_sources` macro accepts a similar node selection syntax to
+[snapshotting source freshness](https://docs.getdbt.com/docs/running-a-dbt-project/command-line-interface/source/#specifying-sources-to-snapshot).
+
+```bash
+# Stage all Snowplow and Logs external sources:
+$ dbt run-operation stage_external_sources --args 'select: snowplow logs'
+
+# Stage a particular external source table:
+$ dbt run-operation stage_external_sources --args 'select: snowplow.event'
+```
+
+Maybe someday:
+```bash
+$ dbt source stage-external
+$ dbt source stage-external --full-refresh
+$ dbt source stage-external --select snowplow.event logs
+```
 
 ### Spec
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_external_tables'
-version: '1.0'
+version: '0.2.0'
 
 require-dbt-version: ">=0.15.0"
 

--- a/macros/external/create_external_table.sql
+++ b/macros/external/create_external_table.sql
@@ -67,7 +67,9 @@
 
 {# https://docs.snowflake.net/manuals/sql-reference/sql/create-external-table.html #}
 {# This assumes you have already created an external stage #}
-    create or replace external table {{source(source_node.source_name, source_node.name)}} (
+    create or replace external table {{source(source_node.source_name, source_node.name)}}
+    {%- if columns|length > 0 -%}    
+    (
         {%- if partitions -%}{%- for partition in partitions %}
             {{partition.name}} {{partition.data_type}} as {{partition.expression}},
         {%- endfor -%}{%- endif -%}
@@ -81,6 +83,7 @@
             {{- ',' if not loop.last -}}
         {% endfor %}
     )
+    {%- endif -%}
     {% if partitions -%} partition by ({{partitions|map(attribute='name')|join(', ')}}) {%- endif %}
     location = {{external.location}} {# stage #}
     {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}

--- a/macros/external/create_external_table.sql
+++ b/macros/external/create_external_table.sql
@@ -1,5 +1,5 @@
 {% macro create_external_table(source_node) %}
-    {{ adapter_macro('create_external_table', source_node) }}
+    {{ adapter_macro('dbt_external_tables.create_external_table', source_node) }}
 {% endmacro %}
 
 {% macro default__create_external_table(source_node) %}

--- a/macros/external/create_snowpipe.sql
+++ b/macros/external/create_snowpipe.sql
@@ -42,7 +42,7 @@
 
 {# https://docs.snowflake.com/en/sql-reference/sql/create-pipe.html #}
     create or replace pipe {{source(source_node.source_name, source_node.name)}}
-        {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
+        {% if external.auto_ingest -%} auto_ingest = {{external.auto_ingest}} {%- endif %}
         {% if external.aws_sns_topic -%} aws_sns_topic = {{external.aws_sns_topic}} {%- endif %}
         {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
         as {{ dbt_external_tables.snowflake_get_copy_sql(source_node) }}

--- a/macros/external/create_snowpipe.sql
+++ b/macros/external/create_snowpipe.sql
@@ -1,0 +1,38 @@
+{% macro create_snowpipe(source_node) %}
+
+    {%- set columns = source_node.columns.values() -%}
+    {%- set external = source_node.external -%}
+    {%- set partitions = external.partitions -%}
+    
+    {%- set is_csv = dbt_external_tables.is_csv(external.file_format) -%}
+
+    create or replace table {{source(source_node.source_name, source_node.name)}} (
+        {%- for column in columns %}
+            {{column.name}} {{column.data_type}}{{- ',' if not loop.last -}}
+        {% endfor %}
+    );
+
+{# https://docs.snowflake.com/en/sql-reference/sql/create-pipe.html #}
+{# This assumes you have already created an external stage #}
+    create or replace pipe {{source(source_node.source_name, source_node.name)}}
+        {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
+        {% if external.aws_sns_topic -%} aws_sns_topic = {{external.aws_sns_topic}} {%- endif %}
+        {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
+        as 
+        copy into {{source(source_node.source_name, source_node.name)}}
+        from (
+            select
+            {%- for column in columns %}
+                {%- set col_expression -%}
+                    {%- if is_csv -%}nullif(value:c{{loop.index}},''){# special case: get columns by ordinal position #}
+                    {%- else -%}nullif(value:{{column.name}},''){# standard behavior: get columns by name #}
+                    {%- endif -%}
+                {%- endset %}
+                {{col_expression}}::{{column.data_type}} as {{column.name}}
+                {{- ',' if not loop.last -}}
+            {% endfor %}
+            from {{external.location}} {# stage #}
+        )
+        file_format = {{external.file_format}}
+
+{% endmacro %}

--- a/macros/external/create_snowpipe.sql
+++ b/macros/external/create_snowpipe.sql
@@ -6,10 +6,12 @@
         {% if columns|length == 0 %}
             value variant,
         {% else -%}
-        {%- for column in columns %}
+        {%- for column in columns -%}
             {{column.name}} {{column.data_type}},
         {% endfor -%}
         {% endif %}
+            metadata_filename varchar,
+            metadata_file_row_number bigint,
             _dbt_copied_at timestamp
     );
 
@@ -35,8 +37,10 @@
                 {%- endif -%}
             {%- endset -%}
             {{col_expression}}::{{column.data_type}} as {{column.name}},
-        {%- endfor -%}
+        {% endfor -%}
         {% endif %}
+            metadata$filename::varchar as metadata_filename,
+            metadata$file_row_number::bigint as metadata_file_row_number,
             current_timestamp::timestamp as _dbt_copied_at
         from {{external.location}} {# stage #}
     )
@@ -60,7 +64,8 @@
 
 {% macro snowflake_refresh_snowpipe(source_node) %}
 
-    {% set auto_ingest = source_node.external.snowpipe.get('auto_ingest', false) %}
+    {% set snowpipe = source_node.external.snowpipe %}
+    {% set auto_ingest = snowpipe.get('auto_ingest', false) if snowpipe is mapping %}
     
     {% if auto_ingest is true %}
     

--- a/macros/external/create_snowpipe.sql
+++ b/macros/external/create_snowpipe.sql
@@ -1,38 +1,50 @@
-{% macro create_snowpipe(source_node) %}
+{% macro snowflake_create_empty_table(source_node) %}
 
     {%- set columns = source_node.columns.values() -%}
-    {%- set external = source_node.external -%}
-    {%- set partitions = external.partitions -%}
-    
-    {%- set is_csv = dbt_external_tables.is_csv(external.file_format) -%}
 
     create or replace table {{source(source_node.source_name, source_node.name)}} (
         {%- for column in columns %}
-            {{column.name}} {{column.data_type}}{{- ',' if not loop.last -}}
+            {{column.name}} {{column.data_type}},
         {% endfor %}
+            _dbt_copied_at timestamp
     );
 
-{# https://docs.snowflake.com/en/sql-reference/sql/create-pipe.html #}
+{% endmacro %}
+
+{% macro snowflake_get_copy_sql(source_node) %}
 {# This assumes you have already created an external stage #}
+
+    {%- set columns = source_node.columns.values() -%}
+    {%- set external = source_node.external -%}
+    {%- set is_csv = dbt_external_tables.is_csv(external.file_format) -%}
+    
+    copy into {{source(source_node.source_name, source_node.name)}}
+    from (
+        select
+        {%- for column in columns %}
+            {%- set col_expression -%}
+                {%- if is_csv -%}nullif(${{loop.index}},''){# special case: get columns by ordinal position #}
+                {%- else -%}nullif($1:{{column.name}},''){# standard behavior: get columns by name #}
+                {%- endif -%}
+            {%- endset %}
+            {{col_expression}}::{{column.data_type}} as {{column.name}},
+        {% endfor %}
+            current_timestamp::timestamp as _dbt_copied_at
+        from {{external.location}} {# stage #}
+    )
+    file_format = {{external.file_format}}
+
+{% endmacro %}
+
+{% macro snowflake_create_snowpipe(source_node) %}
+
+    {%- set external = source_node.external -%}
+
+{# https://docs.snowflake.com/en/sql-reference/sql/create-pipe.html #}
     create or replace pipe {{source(source_node.source_name, source_node.name)}}
         {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
         {% if external.aws_sns_topic -%} aws_sns_topic = {{external.aws_sns_topic}} {%- endif %}
         {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
-        as 
-        copy into {{source(source_node.source_name, source_node.name)}}
-        from (
-            select
-            {%- for column in columns %}
-                {%- set col_expression -%}
-                    {%- if is_csv -%}nullif(value:c{{loop.index}},''){# special case: get columns by ordinal position #}
-                    {%- else -%}nullif(value:{{column.name}},''){# standard behavior: get columns by name #}
-                    {%- endif -%}
-                {%- endset %}
-                {{col_expression}}::{{column.data_type}} as {{column.name}}
-                {{- ',' if not loop.last -}}
-            {% endfor %}
-            from {{external.location}} {# stage #}
-        )
-        file_format = {{external.file_format}}
+        as {{ dbt_external_tables.snowflake_get_copy_sql(source_node) }}
 
 {% endmacro %}

--- a/macros/external/create_snowpipe.sql
+++ b/macros/external/create_snowpipe.sql
@@ -39,12 +39,13 @@
 {% macro snowflake_create_snowpipe(source_node) %}
 
     {%- set external = source_node.external -%}
+    {%- set snowpipe = external.snowpipe -%}
 
 {# https://docs.snowflake.com/en/sql-reference/sql/create-pipe.html #}
     create or replace pipe {{source(source_node.source_name, source_node.name)}}
-        {% if external.auto_ingest -%} auto_ingest = {{external.auto_ingest}} {%- endif %}
-        {% if external.aws_sns_topic -%} aws_sns_topic = {{external.aws_sns_topic}} {%- endif %}
-        {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
+        {% if snowpipe.auto_ingest -%} auto_ingest = {{snowpipe.auto_ingest}} {%- endif %}
+        {% if snowpipe.aws_sns_topic -%} aws_sns_topic = {{snowpipe.aws_sns_topic}} {%- endif %}
+        {% if snowpipe.integration -%} integration = '{{snowpipe.integration}}' {%- endif %}
         as {{ dbt_external_tables.snowflake_get_copy_sql(source_node) }}
 
 {% endmacro %}

--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -1,5 +1,5 @@
 {% macro refresh_external_table(source_node) %}
-    {{ adapter_macro('dbt_external_tables.refresh_external_table', source_node) }}
+    {{ return(adapter_macro('dbt_external_tables.refresh_external_table', source_node)) }}
 {% endmacro %}
 
 {% macro default__refresh_external_table(source_node) %}
@@ -69,11 +69,7 @@
     
     {%- set ddl -%}
 
-    {{ dbt_external_tables.redshift__alter_table_add_partitions(
-        source_node,
-        finals
-      )
-    }}
+    {{ dbt_external_tables.redshift_alter_table_add_partitions(source_node, finals)}}
 
     {%- endset -%}
     

--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -1,5 +1,5 @@
 {% macro refresh_external_table(source_node) %}
-    {{ adapter_macro('refresh_external_table', source_node) }}
+    {{ adapter_macro('dbt_external_tables.refresh_external_table', source_node) }}
 {% endmacro %}
 
 {% macro default__refresh_external_table(source_node) %}

--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -83,8 +83,10 @@
 
 {% macro snowflake__refresh_external_table(source_node) %}
 
+    {% set object_type = 'pipe' if source_node.external.snowpipe == true else 'external table' %}
+
     {% set alter %}
-    alter external table {{source(source_node.source_name, source_node.name)}} refresh
+    alter {{object_type}} {{source(source_node.source_name, source_node.name)}} refresh
     {% endset %}
     
     {{return(alter)}}

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -1,3 +1,34 @@
+{% macro get_external_build_plan(source_node) %}
+    {{ adapter_macro('get_external_build_plan', source_node) }}
+{% endmacro %}
+
+{% macro default__get_external_build_plan(source_node) %}
+    {{ exceptions.raise_compiler_error("Staging external sources is not implemented for the default adapter") }}
+{% endmacro %}
+
+{% macro redshift__get_external_build_plan(source_node) %}
+
+    {% set build_plan = 
+        dropif(source_node) + ';' + 
+        create_external_table(source_node) + ';' + 
+        refresh_external_table(source_node)
+    %}
+    
+    {% do return(build_plan) %}
+
+{% endmacro %}
+
+{% macro snowflake__get_external_build_plan(source_node) %}
+
+    {% set ddl = create_snowpipe(source_node) if source_node.external.snowpipe == true
+        else create_external_table(source_node) %}
+        
+    {% set build_plan = ddl + ';' %}
+
+    {% do return(build_plan) %}
+
+{% endmacro %}
+
 {% macro stage_external_sources() %}
     
     {% for node in graph.nodes.values() %}
@@ -5,22 +36,11 @@
         {% if node.resource_type == 'source' and node.external.location != none %}
         
             {% set ts = modules.datetime.datetime.now().strftime('%H:%M:%S') %}
-            {%- do log(ts ~ ' + Staging external table ' ~ node.schema ~ '.' ~ node.identifier, info = true) -%}
+            {%- do log(ts ~ ' + Staging external source ' ~ node.schema ~ '.' ~ node.identifier, info = true) -%}
             
-            {%- set run_queue = [] -%}
+            {% set run_queue = get_external_build_plan(node).split(';') %}
             
-            {%- if target.type != 'snowflake' -%}
-                {# Snowflake supports "create or replace" #}
-                {%- do run_queue.append(dropif(node))  -%}
-            {%- endif -%}
-            
-            {%- do run_queue.append(create_external_table(node)) -%}
-            
-            {%- if node.external.partitions and target.type == 'redshift' -%}
-                {%- set run_queue = run_queue + refresh_external_table(node).split(';') -%}
-            {%- endif -%}
-            
-            {% for q in (run_queue) %}
+            {% for q in run_queue %}
             
                 {% call statement('runner', fetch_result = True, auto_begin = False) %}
                     {{ q }}

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -34,9 +34,15 @@
             {# create empty table and insert historical data #}
             {{ dbt_external_tables.snowflake_create_empty_table(source_node) }};
             {{ dbt_external_tables.snowflake_get_copy_sql(source_node) }};
+            {{ dbt_external_tables.snowflake_create_snowpipe(source_node) }};
+        {% else %}
+        
+        -- noop
+        
+        select 1 as fun
+        
         {% endif %}
         
-            {{ dbt_external_tables.snowflake_create_snowpipe(source_node) }}
             
     {% else %}
 

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -113,22 +113,22 @@
             
     {% for node in sources_to_stage %}
 
-        {% set src_num = loop.index %}
+        {% set loop_label = loop.index ~ ' of ' ~ loop.length %}
 
-        {% do dbt_utils.log_info(src_num ~ ' of ' ~ loop.length ~ ' START external source ' ~ node.schema ~ '.' ~ node.identifier) -%}
+        {% do dbt_utils.log_info(loop_label ~ ' START external source ' ~ node.schema ~ '.' ~ node.identifier) -%}
         
         {% set run_queue = get_external_build_plan(node) %}
         
         {% for q in run_queue %}
         
-            {% do dbt_utils.log_info(src_num ~ ' (' ~ loop.index ~ ') ' ~ (q|trim)[:30] ~ '...  ') %}
+            {% do dbt_utils.log_info(loop_label ~ ' (' ~ loop.index ~ ') ' ~ (q|trim)[:50] ~ '...  ') %}
         
             {% call statement('runner', fetch_result = True, auto_begin = False) %}
                 {{ q }}
             {% endcall %}
             
             {% set status = load_result('runner')['status'] %}
-            {% do dbt_utils.log_info(src_num ~ ' (' ~ loop.index ~ ') ' ~ status) %}
+            {% do dbt_utils.log_info(loop_label ~ ' (' ~ loop.index ~ ') ' ~ status) %}
             
         {% endfor %}
         

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -22,10 +22,11 @@
     {% if create_or_replace %}
 
         {% set build_plan = [
-            dbt_external_tables.dropif(source_node),
-            dbt_external_tables.create_external_table(source_node),
-            dbt_external_tables.refresh_external_table(source_node)
-        ] %}
+                'commit',
+                dbt_external_tables.dropif(source_node),
+                dbt_external_tables.create_external_table(source_node)
+            ] + dbt_external_tables.refresh_external_table(source_node) 
+        %}
         
     {% else %}
     

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -9,9 +9,9 @@
 {% macro redshift__get_external_build_plan(source_node) %}
 
     {% set build_plan = 
-        dropif(source_node) + ';' + 
-        create_external_table(source_node) + ';' + 
-        refresh_external_table(source_node)
+        dbt_external_tables.dropif(source_node) + ';' + 
+        dbt_external_tables.create_external_table(source_node) + ';' + 
+        dbt_external_tables.refresh_external_table(source_node)
     %}
     
     {% do return(build_plan) %}
@@ -40,7 +40,7 @@
             
     {% else %}
 
-            {{ create_external_table(source_node) }}
+            {{ dbt_external_tables.create_external_table(source_node) }}
         
     {% endif %}
     {% endset %}

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -29,8 +29,11 @@
             schema = source_node.schema, 
             identifier = source_node.identifier
         ) %}
+        
         {% if old_relation is none %}
+            {# create empty table and insert historical data #}
             {{ dbt_external_tables.snowflake_create_empty_table(source_node) }};
+            {{ dbt_external_tables.snowflake_get_copy_sql(source_node) }};
         {% endif %}
         
             {{ dbt_external_tables.snowflake_create_snowpipe(source_node) }}

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -22,7 +22,7 @@
 
     {% set build_plan %}
 
-    {% if source_node.external.snowpipe == true %}
+    {% if source_node.external.snowpipe is not none %}
     
         {% set old_relation = adapter.get_relation(
             database = source_node.database,

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -8,11 +8,30 @@
 
 {% macro redshift__get_external_build_plan(source_node) %}
 
-    {% set build_plan = [
-        dbt_external_tables.dropif(source_node),
-        dbt_external_tables.create_external_table(source_node),
-        dbt_external_tables.refresh_external_table(source_node)
-    ] %}
+    {% set build_plan = [] %}
+
+    {% set old_relation = adapter.get_relation(
+        database = source_node.database,
+        schema = source_node.schema,
+        identifier = source_node.identifier
+    ) %}
+    
+    {%- set partitions = source_node.external.get('partitions', none) -%}
+    {% set create_or_replace = (partitions or old_relation is none or var('ext_full_refresh', false)) %}
+    
+    {% if create_or_replace %}
+
+        {% set build_plan = [
+            dbt_external_tables.dropif(source_node),
+            dbt_external_tables.create_external_table(source_node),
+            dbt_external_tables.refresh_external_table(source_node)
+        ] %}
+        
+    {% else %}
+    
+        {{ dbt_utils.log_info('PASS') }}
+        
+    {% endif %}
     
     {% do return(build_plan) %}
 
@@ -21,33 +40,34 @@
 {% macro snowflake__get_external_build_plan(source_node) %}
 
     {% set build_plan = [] %}
+    
+    {% set old_relation = adapter.get_relation(
+        database = source_node.database,
+        schema = source_node.schema,
+        identifier = source_node.identifier
+    ) %}
+    
+    {% set create_or_replace = (old_relation is none or var('ext_full_refresh', false)) %}
 
     {% if source_node.external.get('snowpipe', none) is not none %}
     
-        {% set old_relation = adapter.get_relation(
-            database = source_node.database,
-            schema = source_node.schema,
-            identifier = source_node.identifier
-        ) %}
-        
-        {% if old_relation is none %}
+        {% if create_or_replace %}
             {% set build_plan = build_plan + [
                 dbt_external_tables.snowflake_create_empty_table(source_node),
                 dbt_external_tables.snowflake_get_copy_sql(source_node),
                 dbt_external_tables.snowflake_create_snowpipe(source_node)
             ] %}
         {% else %}
-        
-            {{ dbt_utils.log_info('PASS') }};
-        
+            {% set build_plan = build_plan + dbt_external_tables.snowflake_refresh_snowpipe(source_node) %}
         {% endif %}
-        
             
     {% else %}
-
-        {% do build_plan.append(
-            dbt_external_tables.create_external_table(source_node)
-        ) %}
+    
+        {% if create_or_replace %}
+            {% set build_plan = build_plan + [dbt_external_tables.create_external_table(source_node)] %}
+        {% else %}
+            {% set build_plan = build_plan + dbt_external_tables.refresh_external_table(source_node) %}
+        {% endif %}
         
     {% endif %}
 

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -25,8 +25,8 @@
     {% if source_node.external.snowpipe == true %}
     
         {% set old_relation = adapter.get_relation(
-            database = source_node.database, 
-            schema = source_node.schema, 
+            database = source_node.database,
+            schema = source_node.schema,
             identifier = source_node.identifier
         ) %}
         

--- a/macros/helpers/common.sql
+++ b/macros/helpers/common.sql
@@ -22,11 +22,9 @@
 {%- endmacro %}
 
 {% macro dropif(node) %}
-
-    {% set fqn = [node.database, node.schema, node.identifier]|join('.') %}
     
     {% set ddl %}
-        drop table if exists {{fqn}} cascade
+        drop table if exists {{source(node.source_name, node.name)}} cascade
     {% endset %}
     
     {{return(ddl)}}

--- a/macros/helpers/redshift/add_partitions.sql
+++ b/macros/helpers/redshift/add_partitions.sql
@@ -22,7 +22,11 @@
 
   {{ log("Generating ADD PARTITION statement for partition set \n" ~ partitions) }}
 
+  {% set ddl = [] %}
+  
   {% if partitions|length > 0 %}
+  
+    {% set alters %}
 
       alter table {{source(source_node.source_name, source_node.name)}} add
 
@@ -39,11 +43,17 @@
         location '{{ source_node.external.location }}{{ partition.path }}/'
 
     {% endfor %}
+    
+    {% endset %}
+    
+    {% set ddl = ddl + alters.split(';') %}
 
   {% else %}
 
-    {{ log("No partitions to be added", info=True) }}
+    {{ log("No partitions to be added") }}
 
   {% endif %}
+  
+  {% do return(ddl) %}
 
 {% endmacro %}

--- a/macros/helpers/redshift/add_partitions.sql
+++ b/macros/helpers/redshift/add_partitions.sql
@@ -18,7 +18,7 @@
           - path (string): The path to be added as a partition for the particular
               combination of columns defined in the 'partition_by'
 #}
-{% macro redshift__alter_table_add_partitions(source_node, partitions) %}
+{% macro redshift_alter_table_add_partitions(source_node, partitions) %}
 
   {{ log("Generating ADD PARTITION statement for partition set \n" ~ partitions) }}
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: fishtown-analytics/dbt_utils
+    version: ">=0.1.25"

--- a/sample_analysis/external_sources_dry_run.sql
+++ b/sample_analysis/external_sources_dry_run.sql
@@ -2,9 +2,9 @@
     
     {%- if node.resource_type == 'source' and node.external.location != none -%}
     
-        {{- dbt_utils.log_info('Staging external source ' ~ node.schema ~ '.' ~ node.identifier) -}}
+        {{ 'Staging external source ' ~ node.schema ~ '.' ~ node.identifier) }}
         
-        {%- set run_queue = dbt_external_tables.get_external_build_plan(node).split(';') -%}
+        {%- set run_queue = dbt_external_tables.get_external_build_plan(node) -%}
         
         {%- for q in run_queue %}
             {{ q }}

--- a/sample_analysis/external_sources_dry_run.sql
+++ b/sample_analysis/external_sources_dry_run.sql
@@ -1,0 +1,17 @@
+{% for node in graph.nodes.values() %}
+    
+    {% if node.resource_type == 'source' and node.external.location != none %}
+    
+        {% set ts = modules.datetime.datetime.now().strftime('%H:%M:%S') %}
+        {%- set msg = ts ~ ' + Staging external source ' ~ node.schema ~ '.' ~ node.identifier -%}
+        {{ msg }}
+        
+        {% set run_queue = dbt_external_tables.get_external_build_plan(node).split(';') %}
+        
+        {% for q in run_queue %}
+            {{ q }}
+        {% endfor %}
+        
+    {% endif %}
+    
+{% endfor %}

--- a/sample_analysis/external_sources_dry_run.sql
+++ b/sample_analysis/external_sources_dry_run.sql
@@ -2,7 +2,7 @@
     
     {%- if node.resource_type == 'source' and node.external.location != none -%}
     
-        {{ 'Staging external source ' ~ node.schema ~ '.' ~ node.identifier) }}
+        {{ 'Staging external source ' ~ node.schema ~ '.' ~ node.identifier }}
         
         {%- set run_queue = dbt_external_tables.get_external_build_plan(node) -%}
         

--- a/sample_analysis/external_sources_dry_run.sql
+++ b/sample_analysis/external_sources_dry_run.sql
@@ -1,17 +1,18 @@
-{% for node in graph.nodes.values() %}
+{%- for node in graph.nodes.values() -%}
     
-    {% if node.resource_type == 'source' and node.external.location != none %}
+    {%- if node.resource_type == 'source' and node.external.location != none -%}
     
-        {% set ts = modules.datetime.datetime.now().strftime('%H:%M:%S') %}
-        {%- set msg = ts ~ ' + Staging external source ' ~ node.schema ~ '.' ~ node.identifier -%}
-        {{ msg }}
+        {{- dbt_utils.log_info('Staging external source ' ~ node.schema ~ '.' ~ node.identifier) -}}
         
-        {% set run_queue = dbt_external_tables.get_external_build_plan(node).split(';') %}
+        {%- set run_queue = dbt_external_tables.get_external_build_plan(node).split(';') -%}
         
-        {% for q in run_queue %}
+        {%- for q in run_queue %}
             {{ q }}
-        {% endfor %}
+            
+            ----------
+            
+        {% endfor -%}
         
-    {% endif %}
+    {%- endif %}
     
-{% endfor %}
+{%- endfor -%}

--- a/sample_sources/snowflake.yml
+++ b/sample_sources/snowflake.yml
@@ -13,6 +13,7 @@ sources:
           location: "@raw.snowplow.snowplow"
           file_format: "( type = json )"
           auto_refresh: "true"
+          snowpipe: false
           partitions:
             - name: collector_hour
               data_type: timestamp


### PR DESCRIPTION
* Resolves #19 
* Depends on #18
* Enable CLI arg to specify which external sources to stage, using syntax similar to [`dbt source snapshot-freshness --select`](https://docs.getdbt.com/docs/running-a-dbt-project/command-line-interface/source/#specifying-sources-to-snapshot)
```bash
# Stage all Snowplow and Logs external sources:
$ dbt run-operation stage_external_sources --args 'select: snowplow logs'
# Stage a particular external source table:
$ dbt run-operation stage_external_sources --args 'select: snowplow.event'
```
* Prettify more detailed log output