### PR TITLE
Bump 0.3.0 (dbt>=0.17.0)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_external_tables'
-version: '0.2.0'
+version: '0.3.0'
 
-require-dbt-version: ">=0.15.0"
+require-dbt-version: ">=0.17.0"
 
 source-paths: ["models"]
 analysis-paths: ["analysis"] 

--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -73,9 +73,9 @@
 
     {% set sources_to_stage = [] %}
     
-    {% for node in graph.nodes.values() %}
+    {% for node in graph.sources.values() %}
         
-        {% if node.resource_type == 'source' and node.external.location != none %}
+        {% if node.external.location != none %}
             
             {% if select %}
             


### PR DESCRIPTION
* For new minor version (0.3.0)
* Require dbt >= 0.17.0
    * Account for `graph` API change: use `graph.sources` instead of `graph.nodes`