### PR TITLE
Fix exclusion of non-external sources from macro

### DIFF
--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -75,7 +75,7 @@
     
     {% for node in graph.sources.values() %}
         
-        {% if node.external.location != none %}
+        {% if node.external.location %}
             
             {% if select %}
             


### PR DESCRIPTION
Source with no `external` property defined were slipping into the `stage_external_sources` macro. A quick switch from checking `!= none` to truthiness does the trick in local testing.