### PR TITLE
Update sample data with proper snowpipe case

### DIFF
--- a/sample_sources/snowflake.yml
+++ b/sample_sources/snowflake.yml
@@ -13,7 +13,6 @@ sources:
           location: "@raw.snowplow.snowplow"
           file_format: "( type = json )"
           auto_refresh: true
-          snowpipe: false
           partitions:
             - name: collector_hour
               data_type: timestamp


### PR DESCRIPTION
Remove invalid snowpipe false config from sample

## Description & motivation
The sample data contained invalid syntax: the check `{% if source_node.external.get('snowpipe', none) is not none %}` views `snowpipe: false` as true and then searches for a non-existent sub-block with error
```
Encountered an error while running operation: Compilation Error in macro snowflake_get_copy_sql (macros/external/create_snowpipe.sql)
  'bool object' has no attribute 'get'
```

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
