### PR TITLE
aws_sns_topic property needs to be quoted in create or replace pipe  …

### DIFF
--- a/macros/external/create_snowpipe.sql
+++ b/macros/external/create_snowpipe.sql
@@ -58,7 +58,7 @@
 {# https://docs.snowflake.com/en/sql-reference/sql/create-pipe.html #}
     create or replace pipe {{source(source_node.source_name, source_node.name)}}
         {% if snowpipe.auto_ingest -%} auto_ingest = {{snowpipe.auto_ingest}} {%- endif %}
-        {% if snowpipe.aws_sns_topic -%} aws_sns_topic = {{snowpipe.aws_sns_topic}} {%- endif %}
+        {% if snowpipe.aws_sns_topic -%} aws_sns_topic = '{{snowpipe.aws_sns_topic}}' {%- endif %}
         {% if snowpipe.integration -%} integration = '{{snowpipe.integration}}' {%- endif %}
         as {{ dbt_external_tables.snowflake_get_copy_sql(source_node) }}
 


### PR DESCRIPTION
…statement according to doc

## Description & motivation
<!---
Current snowpipe macro does not escape aws_sns_topic property in pipe creation statement, because of that, pipe creation is failing when  stage_external_sources  macro is run
-->

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
