### PR TITLE
Support running stage_external_sources as a hook

### DIFF
--- a/macros/external/stage_external_sources.sql
+++ b/macros/external/stage_external_sources.sql
@@ -73,7 +73,9 @@
 
     {% set sources_to_stage = [] %}
     
-    {% for node in graph.sources.values() %}
+    {% set source_nodes = graph.sources.values() if graph.sources else [] %}
+    
+    {% for node in source_nodes %}
         
         {% if node.external.location %}
             
@@ -110,7 +112,7 @@
 
         {% do dbt_utils.log_info(loop_label ~ ' START external source ' ~ node.schema ~ '.' ~ node.identifier) -%}
         
-        {% set run_queue = get_external_build_plan(node) %}
+        {% set run_queue = dbt_external_tables.get_external_build_plan(node) %}
         
         {% do dbt_utils.log_info(loop_label ~ ' SKIP') if run_queue == [] %}
         


### PR DESCRIPTION
Resolves #34 by addressing two errors that currently pop up when trying to run `stage_external_sources` as a hook instead of an operation

* Check that `graph.sources` is populated before trying to grab its `values()`
* Add package namespace for `get_external_build_plan()` call