### PR TITLE
Added in the ability to create columns on Snowflake external tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ sources:
             - name: collector_date
               data_type: date
               expression: to_date(substr(metadata$filename, 8, 10), 'YYYY/MM/DD')
-              
+          
+          # ------ SNOWFLAKE - Calculated Columns ------
+          calc_columns:
+            - name: landed_time
+              data_type: time
+              expression: "IFF(try_to_time(substr(metadata$filename, 75, 6), 'HH24MISS') IS NOT NULL, to_time(substr(metadata$filename, 75, 6), 'HH24MISS'), to_time('080000', 'HH24MISS'))"
+          
           # ------ REDSHIFT -------
           partitions:
             - name: appId

--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -92,9 +92,13 @@
     
     {% if manual_refresh %}
 
+        {% set ddl %}
         BEGIN;
         alter external table {{source(source_node.source_name, source_node.name)}} refresh;
         COMMIT;
+        {% endset %}
+
+         {% do return([ddl]) %}
 
     {% else %}
     

--- a/macros/external/refresh_external_table.sql
+++ b/macros/external/refresh_external_table.sql
@@ -92,12 +92,10 @@
     
     {% if manual_refresh %}
 
-        {% set ddl %}
-        alter external table {{source(source_node.source_name, source_node.name)}} refresh
-        {% endset %}
-        
-        {% do return([ddl]) %}
-    
+        BEGIN;
+        alter external table {{source(source_node.source_name, source_node.name)}} refresh;
+        COMMIT;
+
     {% else %}
     
         {% do return([]) %}

--- a/sample_sources/snowflake.yml
+++ b/sample_sources/snowflake.yml
@@ -17,6 +17,10 @@ sources:
             - name: collector_hour
               data_type: timestamp
               expression: to_timestamp(substr(metadata$filename, 8, 13), 'YYYY/MM/DD/HH24')
+          calc_columns:
+            - name: landed_time
+              data_type: time
+              expression: "IFF(try_to_time(substr(metadata$filename, 75, 6), 'HH24MISS') IS NOT NULL, to_time(substr(metadata$filename, 75, 6), 'HH24MISS'), to_time('080000', 'HH24MISS'))"
         columns:
           - name: app_id
             data_type: varchar(255)


### PR DESCRIPTION
… them in the schema.yml.  external -> calc_columns

## Description & motivation
Related to the issue described here: https://github.com/fishtown-analytics/dbt-external-tables/issues/28

Basically, I just added in another dictionary under the external node to specify calculated columns. 

Example schema.yml:

```
- name: my_external_table
        identifier: my_external_table
        external: 
          location: "@BUCKETNAME"
          file_format: csv_file_format
          auto_refresh: true
          partitions:
            - name: landed_day
              data_type: date
              expression: to_date(substr(metadata$filename, 32, 10), 'YYYY-MM-DD')
          calc_columns:
            - name: landed_time
              data_type: time
              expression: "IFF(try_to_time(substr(metadata$filename, 75, 6), 'HH24MISS') IS NOT NULL, to_time(substr(metadata$filename, 75, 6), 'HH24MISS'), to_time('080000', 'HH24MISS'))"
        columns:
          - name: key
            data_type: NUMBER(16)
          - name: name
            data_type: string(32)
```

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
