### PR TITLE
enable Azure SQL's "elastic query"-style external tables (RDBMS / cross-database)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - store_artifacts:
           path: ./logs
 
-  integration-sqlserver:
+  integration-synapse:
     docker:
       - image: dataders/pyodbc:1.2
     steps:
@@ -89,4 +89,5 @@ workflows:
       - integration-snowflake
       - integration-bigquery
       - integration-databricks
-      - integration-sqlserver
+      - integration-synapse
+      - integration-azuresql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,17 @@ jobs:
       - store_artifacts:
           path: ./logs
 
+  integration-azuresql:
+    docker:
+      - image: dataders/pyodbc:1.2
+    steps:
+      - checkout
+      - run:
+          name: "Run Tests - azuresql"
+          command: ./run_test.sh azuresql
+      - store_artifacts:
+          path: ./logs
+
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - checkout
       - run:
           name: "Run Tests - sqlserver"
-          command: ./run_test.sh sqlserver
+          command: ./run_test.sh synapse
       - store_artifacts:
           path: ./logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "wait for Synapse tests to finish"
+          command: sleep 60
+      - run:
           name: "Run Tests - azuresql"
           command: ./run_test.sh azuresql
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Run Tests - sqlserver"
+          name: "Run Tests - Synapse"
           command: ./run_test.sh synapse
       - store_artifacts:
           path: ./logs

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This package provides:
 * BigQuery
 * Spark
 * Synapse
+* Azure SQL
 
 ![sample docs](etc/sample_docs.png)
 
@@ -46,6 +47,7 @@ The macros assume that you:
   - an external stage (Snowflake)
   - an external schema + S3 bucket (Redshift Spectrum)
   - an external data source and file format (Synapse)
+  - an external data source and databse-scoped credential (Azure SQL)
   - a Google Cloud Storage bucket (BigQuery)
   - an accessible set of files (Spark)
 2. Have the appropriate permissions on to create tables using that scaffolding

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -71,6 +71,6 @@ integration_tests:
       username: "{{ env_var('DBT_AZURESQL_UID') }}"
       password: "{{ env_var('DBT_AZURESQL_PWD') }}"
       schema: dbt_external_tables_integration_tests_azuresql
-      encrypt: 'yes'
-      trust_cert: 'yes'
+      encrypt: yes
+      trust_cert: yes
       threads: 1

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -49,7 +49,7 @@ integration_tests:
       token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
       schema: dbt_external_tables_integration_tests_databricks
 
-    sqlserver:
+    synapse:
       type: sqlserver
       driver: "ODBC Driver 17 for SQL Server"
       port: 1433
@@ -58,6 +58,19 @@ integration_tests:
       username: "{{ env_var('DBT_SYNAPSE_UID') }}"
       password: "{{ env_var('DBT_SYNAPSE_PWD') }}"
       schema: dbt_external_tables_integration_tests_synapse
+      encrypt: 'yes'
+      trust_cert: 'yes'
+      threads: 1
+
+    azuresql:
+      type: sqlserver
+      driver: "ODBC Driver 17 for SQL Server"
+      port: 1433
+      host: "{{ env_var('DBT_AZURESQL_SERVER') }}"
+      database: "{{ env_var('DBT_AZURESQL_DB') }}"
+      username: "{{ env_var('DBT_AZURESQL_UID') }}"
+      password: "{{ env_var('DBT_AZURESQL_PWD') }}"
+      schema: dbt_external_tables_integration_tests_azuresql
       encrypt: 'yes'
       trust_cert: 'yes'
       threads: 1

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -33,8 +33,10 @@ sources:
         +enabled: "{{ target.type == 'bigquery' }}"
       spark_external:
         +enabled: "{{ target.type == 'spark' }}"
-      sqlserver_external:
-        +enabled: "{{ target.type == 'sqlserver' }}"
+      synapse_external:
+        +enabled: "{{ target.name == 'synapse' }}"
+      azuresql_external:
+        +enabled: "{{ target.name == 'azuresql' }}"
 
 seeds:
   quote_columns: false

--- a/integration_tests/macros/plugins/sqlserver/prep_external.sql
+++ b/integration_tests/macros/plugins/sqlserver/prep_external.sql
@@ -1,35 +1,71 @@
 {% macro sqlserver__prep_external() %}
 
     {% set external_data_source = target.schema ~ '.dbt_external_tables_testing' %}
-    
-    {% set create_external_data_source %}
-        IF NOT EXISTS ( SELECT * FROM sys.external_data_sources WHERE name = '{{external_data_source}}' )
 
-        CREATE EXTERNAL DATA SOURCE [{{external_data_source}}] WITH (
-            TYPE = HADOOP,
-            LOCATION = 'wasbs://dbt-external-tables-testing@dbtsynapselake.blob.core.windows.net'
-        )
-    {% endset %}
+    {% if target.name == "synapse"%}
 
-    {% set external_file_format = target.schema ~ '.dbt_external_ff_testing' %}
+        {% set create_external_data_source %}
+            IF NOT EXISTS ( SELECT * FROM sys.external_data_sources WHERE name = '{{external_data_source}}' )
 
-    {% set create_external_file_format %}
-        IF NOT EXISTS ( SELECT * FROM sys.external_file_formats WHERE name = '{{external_file_format}}' )
-
-        CREATE EXTERNAL FILE FORMAT [{{external_file_format}}] 
-        WITH (
-            FORMAT_TYPE = DELIMITEDTEXT, 
-            FORMAT_OPTIONS (
-                FIELD_TERMINATOR = N',', 
-                FIRST_ROW = 2, 
-                USE_TYPE_DEFAULT = True
+            CREATE EXTERNAL DATA SOURCE [{{external_data_source}}] WITH (
+                TYPE = HADOOP,
+                LOCATION = 'wasbs://dbt-external-tables-testing@dbtsynapselake.blob.core.windows.net'
             )
-        )
-    {% endset %}
+        {% endset %}
+
+        {% set external_file_format = target.schema ~ '.dbt_external_ff_testing' %}
+
+        {% set create_external_file_format %}
+            IF NOT EXISTS ( SELECT * FROM sys.external_file_formats WHERE name = '{{external_file_format}}' )
+
+            CREATE EXTERNAL FILE FORMAT [{{external_file_format}}] 
+            WITH (
+                FORMAT_TYPE = DELIMITEDTEXT, 
+                FORMAT_OPTIONS (
+                    FIELD_TERMINATOR = N',', 
+                    FIRST_ROW = 2, 
+                    USE_TYPE_DEFAULT = True
+                )
+            )
+        {% endset %}
+
+    {% elif target.name == "azuresql" %}
+
+        {% set cred_name = 'synapse_reader' %}
+
+        {% set create_database_scoped_credential %}
+            IF NOT EXISTS ( SELECT * FROM sys.create_database_scoped_credentials WHERE name = {{ cred_name }})
+                CREATE DATABASE SCOPED CREDENTIAL [{{ cred_name }}] WITH
+                    IDENTITY = "{{ env_var('DBT_SYNAPSE_UID') }}",
+                    SECRET = "{{ env_var('DBT_SYNAPSE_PWD') }}"
+
+        {% endset %}
+
+        {% set create_external_data_source %}
+            IF NOT EXISTS ( SELECT * FROM sys.external_data_sources WHERE name = '{{external_data_source}}' )
+
+            CREATE EXTERNAL DATA SOURCE [{{external_data_source}}] WITH (
+                TYPE = RDBMS,
+                LOCATION = '{{ env_var("DBT_SYNAPSE_SERVER") }}',
+                DATABASE_NAME = '{{ env_var("DBT_SYNAPSE_DB") }}',
+                CREDENTIAL = [{{ cred_name }}]
+            )
+        {% endset %}
+
+    {%- endif %}
     
+
+    {% if target.name == "azuresql" -%}
+        {% do log('Creating database scoped credential ' ~ cred_name, info = true) %}
+        {% do run_query(create_database_scoped_credential) %}
+    {%- endif %}
+
     {% do log('Creating external data source ' ~ external_data_source, info = true) %}
     {% do run_query(create_external_data_source) %}
-    {% do log('Creating external file format ' ~ external_file_format, info = true) %}
-    {% do run_query(create_external_file_format) %}
-    
+
+    {% if target.name == "synapse" -%}
+        {% do log('Creating external file format ' ~ external_file_format, info = true) %}
+        {% do run_query(create_external_file_format) %}
+    {%- endif %}
+
 {% endmacro %}

--- a/integration_tests/macros/plugins/sqlserver/prep_external.sql
+++ b/integration_tests/macros/plugins/sqlserver/prep_external.sql
@@ -34,10 +34,10 @@
         {% set cred_name = 'synapse_reader' %}
 
         {% set create_database_scoped_credential %}
-            IF NOT EXISTS ( SELECT * FROM sys.create_database_scoped_credentials WHERE name = {{ cred_name }})
+            IF NOT EXISTS ( SELECT * FROM sys.database_scoped_credentials WHERE name = '{{ cred_name }}')
                 CREATE DATABASE SCOPED CREDENTIAL [{{ cred_name }}] WITH
-                    IDENTITY = "{{ env_var('DBT_SYNAPSE_UID') }}",
-                    SECRET = "{{ env_var('DBT_SYNAPSE_PWD') }}"
+                    IDENTITY = '{{ env_var("DBT_SYNAPSE_UID") }}',
+                    SECRET = '{{ env_var("DBT_SYNAPSE_PWD") }}'
 
         {% endset %}
 

--- a/integration_tests/models/plugins/sqlserver.yml
+++ b/integration_tests/models/plugins/sqlserver.yml
@@ -50,8 +50,8 @@ sources:
     loader: RDBMS cross database query
     tables:
       - name: people_csv_unpartitioned
-        external: &csv-people
-          data_source: "{{ target.schema ~ '.dbt_external_tables_testing' }}"
+        external:
+          <<: *csv-people
           schema_name: "{{ target.schema }}"
           object_name: people_csv_unpartitioned
         columns: *cols-of-the-people

--- a/integration_tests/models/plugins/sqlserver.yml
+++ b/integration_tests/models/plugins/sqlserver.yml
@@ -51,11 +51,12 @@ sources:
     tables:
       - name: people_csv_unpartitioned
         external:
-          <<: *csv-people
-          schema_name: "{{ target.schema }}"
-          object_name: people_csv_unpartitioned
+          data_source: "{{ target.schema ~ '.dbt_external_tables_testing' }}"
+          schema_name: 'dbt_external_tables_integration_tests_synapse'
+          object_name: 'people_csv_unpartitioned'
         columns: *cols-of-the-people
         tests: *equal-to-the-people
+
       # TODO: JSON IS NOT SUPPORTED BY SYNAPSE ATM
 
       # - name: people_json_unpartitioned

--- a/integration_tests/models/plugins/sqlserver.yml
+++ b/integration_tests/models/plugins/sqlserver.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sources:
-  - name: sqlserver_external
+  - name: synapse_external
     schema: "{{ target.schema }}"
     loader: ADLSblob
 
@@ -45,7 +45,17 @@ sources:
           #     expression: "substr(split_part(metadata$filename, 'section=', 2), 1, 1)"
         columns: *cols-of-the-people
         tests: *equal-to-the-people
-
+  - name: azuresql_external
+    schema: "{{ target.schema }}"
+    loader: RDBMS cross database query
+    tables:
+      - name: people_csv_unpartitioned
+        external: &csv-people
+          data_source: "{{ target.schema ~ '.dbt_external_tables_testing' }}"
+          schema_name: "{{ target.schema }}"
+          object_name: people_csv_unpartitioned
+        columns: *cols-of-the-people
+        tests: *equal-to-the-people
       # TODO: JSON IS NOT SUPPORTED BY SYNAPSE ATM
 
       # - name: people_json_unpartitioned

--- a/integration_tests/models/plugins/sqlserver.yml
+++ b/integration_tests/models/plugins/sqlserver.yml
@@ -42,7 +42,6 @@ sources:
           # partitions: &parts-of-the-people
           #   - name: section
           #     data_type: varchar
-          #     expression: "substr(split_part(metadata$filename, 'section=', 2), 1, 1)"
         columns: *cols-of-the-people
         tests: *equal-to-the-people
   - name: azuresql_external

--- a/macros/common/stage_external_sources.sql
+++ b/macros/common/stage_external_sources.sql
@@ -5,7 +5,7 @@
     {% set source_nodes = graph.sources.values() if graph.sources else [] %}
     
     {% for node in source_nodes %}
-        {% if node.external.items() %}
+        {% if node.external %}
             
             {% if select %}
             

--- a/macros/common/stage_external_sources.sql
+++ b/macros/common/stage_external_sources.sql
@@ -6,7 +6,6 @@
     
     {% for node in source_nodes %}
         
-        {% if node.external.location %}
             
             {% if select %}
             
@@ -31,7 +30,6 @@
                 
             {% endif %}
             
-        {% endif %}
         
     {% endfor %}
             

--- a/macros/common/stage_external_sources.sql
+++ b/macros/common/stage_external_sources.sql
@@ -5,7 +5,7 @@
     {% set source_nodes = graph.sources.values() if graph.sources else [] %}
     
     {% for node in source_nodes %}
-        
+        {% if node.external.items() %}
             
             {% if select %}
             
@@ -29,7 +29,7 @@
                 {% do sources_to_stage.append(node) %}
                 
             {% endif %}
-            
+        {% endif %}
         
     {% endfor %}
             

--- a/macros/plugins/sqlserver/create_external_table.sql
+++ b/macros/plugins/sqlserver/create_external_table.sql
@@ -16,7 +16,7 @@
     )
     WITH (
         {# remove keys that are None (i.e. not defined for a given source) #}
-        {%- for key, value in external.items() if value and key not in ['ansi_nulls', 'quoted_identifier'] -%}
+        {%- for key, value in external.items() if value is not none and key not in ['ansi_nulls', 'quoted_identifier'] -%}
             {{key}} = 
                 {%- if key in ["location", "schema_name", "object_name"] -%}
                     '{{value}}'

--- a/macros/plugins/sqlserver/create_external_table.sql
+++ b/macros/plugins/sqlserver/create_external_table.sql
@@ -3,6 +3,25 @@
     {%- set columns = source_node.columns.values() -%}
     {%- set external = source_node.external -%}
 
+    {% set query %}
+        SELECT Type_desc
+        FROM [sys].[external_data_sources]
+        WHERE Name = '{{external.data_source}}'
+    {% endset %}
+    {% set results = run_query(query) %}
+    {% set datasource_type = results.columns[0].values()[0] %}
+
+    {%- if datasource_type == "HADOOP" -%}
+    {% set dict = {'DATA_SOURCE': external.data_source,
+                    'LOCATION' : external.location, 
+                    'FILE_FORMAT' : external.file_format, 
+                    'REJECT_TYPE' : external.reject_type, 
+                    'REJECT_VALUE' : external.reject_value} -%}
+    {%- elif datasource_type == "RDBMS" -%}
+    {% set dict = {'DATA_SOURCE': external.data_source,
+                    'SCHEMA_NAME' : external.schema_name, 
+                    'OBJECT_NAME' : external.object_name} -%}
+    {%- endif %}
     {% if external.ansi_nulls is true -%} SET ANSI_NULLS ON; {%- endif %}
     {% if external.quoted_identifier is true -%} SET QUOTED_IDENTIFIER ON; {%- endif %}
 
@@ -15,11 +34,6 @@
         {% endfor %}
     )
     WITH (
-        {% set dict = {'DATA_SOURCE': external.data_source,
-                       'LOCATION' : external.location, 
-                       'FILE_FORMAT' : external.file_format, 
-                       'REJECT_TYPE' : external.reject_type, 
-                       'REJECT_VALUE' : external.reject_value} -%}
         {%- for key, value in dict.items() %}
             {{key}} = {% if key == "LOCATION" -%} '{{value}}' {%- elif key in ["DATA_SOURCE","FILE_FORMAT"] -%} [{{value}}] {%- else -%} {{value}} {%- endif -%}
             {{- ',' if not loop.last -}}

--- a/macros/plugins/sqlserver/create_external_table.sql
+++ b/macros/plugins/sqlserver/create_external_table.sql
@@ -16,7 +16,7 @@
     )
     WITH (
         {# remove keys that are None (i.e. not defined for a given source) #}
-        {%- for key, value in external.items() if value %}
+        {%- for key, value in external.items() if value and key not in ['ansi_nulls', 'quoted_identifier'] -%}
             {{key}} = 
                 {%- if key in ["location", "schema_name", "object_name"] -%}
                     '{{value}}'

--- a/macros/plugins/sqlserver/create_external_table.sql
+++ b/macros/plugins/sqlserver/create_external_table.sql
@@ -20,9 +20,9 @@
             {{key}} = 
                 {%- if key in ["location", "schema_name", "object_name"] -%}
                     '{{value}}'
-                {%- elif key in ["data_source","file_format"] -%}
+                {% elif key in ["data_source","file_format"] -%}
                     [{{value}}]
-                {%- else -%}
+                {% else -%}
                     {{value}}
                 {%- endif -%}
             {{- ',' if not loop.last -}}

--- a/macros/plugins/sqlserver/create_external_table.sql
+++ b/macros/plugins/sqlserver/create_external_table.sql
@@ -18,7 +18,7 @@
         {# remove keys that are None (i.e. not defined for a given source) #}
         {%- for key, value in external.items() if value is not none and key not in ['ansi_nulls', 'quoted_identifier'] -%}
             {{key}} = 
-                {%- if key in ["location", "schema_name", "object_name", 'type'] -%}
+                {%- if key in ["location", "schema_name", "object_name"] -%}
                     '{{value}}'
                 {% elif key in ["data_source","file_format"] -%}
                     [{{value}}]

--- a/macros/plugins/sqlserver/create_external_table.sql
+++ b/macros/plugins/sqlserver/create_external_table.sql
@@ -18,7 +18,7 @@
         {# remove keys that are None (i.e. not defined for a given source) #}
         {%- for key, value in external.items() if value is not none and key not in ['ansi_nulls', 'quoted_identifier'] -%}
             {{key}} = 
-                {%- if key in ["location", "schema_name", "object_name"] -%}
+                {%- if key in ["location", "schema_name", "object_name", 'type'] -%}
                     '{{value}}'
                 {% elif key in ["data_source","file_format"] -%}
                     [{{value}}]

--- a/macros/plugins/sqlserver/create_external_table.sql
+++ b/macros/plugins/sqlserver/create_external_table.sql
@@ -35,7 +35,14 @@
     )
     WITH (
         {%- for key, value in dict.items() %}
-            {{key}} = {% if key == "LOCATION" -%} '{{value}}' {%- elif key in ["DATA_SOURCE","FILE_FORMAT"] -%} [{{value}}] {%- else -%} {{value}} {%- endif -%}
+            {{key}} = 
+                {%- if key in ["LOCATION", "SCHEMA_NAME", "OBJECT_NAME"] -%}
+                    '{{value}}'
+                {%- elif key in ["DATA_SOURCE","FILE_FORMAT"] -%}
+                    [{{value}}]
+                {%- else -%}
+                    {{value}}
+                {%- endif -%}
             {{- ',' if not loop.last -}}
             {%- endfor -%}
     )

--- a/run_test.sh
+++ b/run_test.sh
@@ -11,6 +11,9 @@ if [[ ! -f $VENV ]]; then
     elif [ $1 == 'sqlserver' ]
     then
         pip install dbt-synapse --upgrade
+    elif [ $1 == 'azuresql' ]
+    then
+        pip install dbt-sqlserver --upgrade
     else
         pip install dbt --upgrade
     fi

--- a/sample_sources/synapse.yml
+++ b/sample_sources/synapse.yml
@@ -11,13 +11,21 @@ sources:
         description: |
           from raw DW.
         external:
-          data_source: SynapseContainer # External Data Source name (created prior)
+        # Delimited Files in Blob/Lake
+          # External Data Source name (created prior)
+          data_source: SynapseContainer # made with TYPE= 'HADOOP'
           location: /marketing/Marketo/LeadActivities/ # path on above data source
-          file_format: CommaDelimited # External File Format name (created prior)
+          # External File Format name (created prior)
+          file_format: CommaDelimited 
           reject_type: VALUE
           reject_value: 0
           ansi_nulls: true
           quoted_identifier: true
+
+        # Cross database query (i.e. RDBMS) Azure SQL ONLY
+          data_source: AEDW # made with TYPE= 'RDBMS'
+          schema_name: Business
+          object_name: LeadActivities
 
         columns:
           - name: id


### PR DESCRIPTION
## Description & motivation
The Synapse team does not recommend having end-users connect directly to the Synapse DW (due to concurrency limits). Instead, they recommend a "mart"-itechture approach where data from the DW into a downstream SQL db. Our team's vision is to have external tables in our Azure SQL marts that point to tables in our upstream Synapse DW.

[Here's a docs page about Azure SQL elastic queries](https://docs.microsoft.com/en-us/azure/azure-sql/database/elastic-query-overview?WT.mc_id=DP-MVP-5003930)

## Testing Approach

As this functionality needs two databases to work, my thought is to use the Synapse db as the source, which will get created during the Synapse integration testing. Then the Azure SQL step will query against the people table that was created in the previous step.

## Checklist
- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [ ] Solve the issue of Azure SQL External Tables not having a `LOCATION` param
- [x] Pass Azure SQL creds to @jtcohen6 
- [x] Get integration test working for Azure SQL
