### PR TITLE
fix opposite logic

### DIFF
--- a/macros/plugins/sqlserver/create_external_table.sql
+++ b/macros/plugins/sqlserver/create_external_table.sql
@@ -9,7 +9,7 @@
     create external table {{source(source_node.source_name, source_node.name)}} (
         {% for column in columns %}
             {# TODO set nullity based on schema tests?? #}
-            {%- set nullity = 'NULL' if 'not_null' in columns.tests else 'NOT NULL'-%}
+            {%- set nullity = 'NOT NULL' if 'not_null' in columns.tests else 'NULL'-%}
             {{adapter.quote(column.name)}} {{column.data_type}} {{nullity}}
             {{- ',' if not loop.last -}}
         {% endfor %}


### PR DESCRIPTION
## Description & motivation
This conditional logic was reversed so that if there if the column test, `'not_null'` was NOT present, then the column would be defined as a NOT NULL column 🤦 . This PR reverses things so that all columns are nullable by default unless otherwise specified.

So if any external table had a null value, any downstream table materialization would break with the following error:
```
Database Error in model tbl_WBSE_Services (models/finance/tbl_WBSE_Services.sql)
  ('42000', "[42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Attempting to set a non-NULL-able column's value to NULL. (681) (SQLExecDirectW)")
  compiled SQL at target/run/finance_data/models/finance/tbl_WBSE_Services.sql

Done. PASS=41 WARN=0 ERROR=1 SKIP=2 TOTAL=44
```


## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
