### PR TITLE
fix for Azure SQL Serverless Connectivty issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,10 @@ jobs:
       - run:
           name: "Run Tests - azuresql"
           command: ./run_test.sh azuresql
+      - run:
+          name: "Run Tests - azuresql (retry when server is off)"
+          command: ./run_test.sh azuresql
+          when: on_fail
       - store_artifacts:
           path: ./logs
 


### PR DESCRIPTION
## Description & motivation
So it turns out the "serverless" tier of Azure SQL db we're using will auto-pause. To wake it up you have to try and log-in once, have it fail, then try again. Long term, def need to move this testing to a standard tier db, but short term this should work. [Per this doc page](https://docs.microsoft.com/en-us/azure/azure-sql/database/serverless-tier-overview#connectivity)
> If a serverless database is paused, then the first login will resume the database and return an error stating that the database is unavailable with error code 40613. Once the database is resumed, the login must be retried to establish connectivity. Database clients with connection retry logic should not need to be modified.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
