### PR TITLE
Non-breaking update for v0.19.0

### DIFF
--- a/macros/common/stage_external_sources.sql
+++ b/macros/common/stage_external_sources.sql
@@ -56,7 +56,7 @@
             {% endcall %}
             
             {% set runner = load_result('runner') %}
-            {% set log_msg = runner['response'] if response in runner.keys() else runner['status'] %}
+            {% set log_msg = runner['response'] if 'response' in runner.keys() else runner['status'] %}
             {% do dbt_utils.log_info(loop_label ~ ' (' ~ loop.index ~ ') ' ~ log_msg) %}
             
         {% endfor %}

--- a/macros/common/stage_external_sources.sql
+++ b/macros/common/stage_external_sources.sql
@@ -55,8 +55,9 @@
                 {{ exit_txn }} {{ q }}
             {% endcall %}
             
-            {% set status = load_result('runner')['status'] %}
-            {% do dbt_utils.log_info(loop_label ~ ' (' ~ loop.index ~ ') ' ~ status) %}
+            {% set runner = load_result('runner') %}
+            {% set log_msg = runner['response'] if response in runner.keys() else runner['status'] %}
+            {% do dbt_utils.log_info(loop_label ~ ' (' ~ loop.index ~ ') ' ~ log_msg) %}
             
         {% endfor %}
         

--- a/run_test.sh
+++ b/run_test.sh
@@ -7,15 +7,15 @@ if [[ ! -f $VENV ]]; then
     pip install --upgrade pip setuptools
     if [ $1 == 'databricks' ]
     then
-        pip install dbt-spark[ODBC] --upgrade
+        pip install --pre dbt-spark[ODBC] --upgrade
     elif [ $1 == 'synapse' ]
     then
-        pip install dbt-synapse --upgrade
+        pip install --pre dbt-synapse --upgrade
     elif [ $1 == 'azuresql' ]
     then
-        pip install dbt-sqlserver --upgrade
+        pip install --pre dbt-sqlserver --upgrade
     else
-        pip install dbt --upgrade
+        pip install --pre dbt --upgrade
     fi
 fi
 


### PR DESCRIPTION
In v0.19.0, statements return `response` instead of `status`. See https://github.com/fishtown-analytics/docs.getdbt.com/pull/504.

This should be a nice test of backwards- and forwards-compatibility, since core adapters will run their integration tests on v0.19.0-rc1 whereas spark + synapse/azure will run on v0.18.

## Checklist
- [x] I have verified that these changes work locally
- ~I have updated the README.md (if applicable)~
- ~I have added tests & descriptions to my models (and macros if applicable)~
