### PR TITLE
Redshift partition values: avoid numeric coercion

### DIFF
--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -58,8 +58,8 @@ integration_tests:
       username: "{{ env_var('DBT_SYNAPSE_UID') }}"
       password: "{{ env_var('DBT_SYNAPSE_PWD') }}"
       schema: dbt_external_tables_integration_tests_synapse
-      encrypt: 'yes'
-      trust_cert: 'yes'
+      encrypt: no
+      trust_cert: yes
       threads: 1
 
     azuresql:

--- a/macros/plugins/redshift/refresh_external_table.sql
+++ b/macros/plugins/redshift/refresh_external_table.sql
@@ -25,9 +25,9 @@
             {%- for val in vals %}
             
                 select
-                    '{{ partition.name }}' as name_{{ part_num }},
-                    '{{ val }}' as val_{{ part_num }},
-                    '{{ dbt_external_tables.render_from_context(partition.path_macro, partition.name, val) }}' as path_{{ part_num }}
+                    '"{{ partition.name }}"' as name_{{ part_num }},
+                    '"{{ val }}"' as val_{{ part_num }},
+                    '"{{ dbt_external_tables.render_from_context(partition.path_macro, partition.name, val) }}"' as path_{{ part_num }}
                 
                 {{ 'union all' if not loop.last else ') ' }}
             
@@ -50,16 +50,18 @@
                 
                 {%- for i in range(0, part_len) -%}
                     {%- do partition_parts.append({
-                        'name': row[i * 3],
-                        'value': row[i * 3 + 1]
+                        'name': row[i * 3][1:-1],
+                        'value': row[i * 3 + 1][1:-1]
                     }) -%}
-                    {%- do path_parts.append(row[i * 3 + 2]) -%}
+                    {%- do path_parts.append(row[i * 3 + 2][1:-1]) -%}
                 {%- endfor -%}
                 
                 {%- set construct = {
                     'partition_by': partition_parts,
                     'path': path_parts | join('/')
                 }  -%}
+                
+                {% do log(construct, info = true) %}
                 
                 {% do finals.append(construct) %}
             {%- endfor -%}

--- a/macros/plugins/redshift/refresh_external_table.sql
+++ b/macros/plugins/redshift/refresh_external_table.sql
@@ -61,8 +61,6 @@
                     'path': path_parts | join('/')
                 }  -%}
                 
-                {% do log(construct, info = true) %}
-                
                 {% do finals.append(construct) %}
             {%- endfor -%}
         {%- endif -%}


### PR DESCRIPTION
Fixes #69

It's a little bit hacky: wrap values with extra double quotes to avoid type coercion during the journey to and from Redshift, then strip the first and last character.

@dm03514 When you get a chance, could you try out this fix? In **packages.yml**:
```yml
packages:
  - git: https://github.com/fishtown-analytics/dbt-external-tables
    revision: fix/redshift-quote-extra-safe
```

## Checklist
- [x] I have verified that these changes work locally
- ~I have updated the README.md (if applicable)~
- [ ] I have added an integration test for my fix/feature (if applicable) — To do this, I'd first need to upload some new fixture data to S3.
