### PR TITLE
Snowflake Azure: auto refresh external tables

### DIFF
--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -29,6 +29,6 @@
     location = {{external.location}} {# stage #}
     {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
     {% if external.pattern -%} pattern = '{{external.pattern}}' {%- endif %}
-    {% if external.integration -%} integration = {{external.integration}} {%- endif %}
+    {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
     file_format = {{external.file_format}}
 {% endmacro %}

--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -29,5 +29,6 @@
     location = {{external.location}} {# stage #}
     {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
     {% if external.pattern -%} pattern = '{{external.pattern}}' {%- endif %}
+    {% if external.integration -%} integration = {{external.integration}} {%- endif %}
     file_format = {{external.file_format}}
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation
Adds the parameter `integration` for external tables on Snowflake. This is required for auto refresh on Snowflake on Azure.

closes #86

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
