### PR TITLE
wrap options.items() values in single quotes

### DIFF
--- a/macros/plugins/bigquery/create_external_table.sql
+++ b/macros/plugins/bigquery/create_external_table.sql
@@ -30,7 +30,7 @@
             uris = [{%- for uri in uris -%} '{{uri}}' {{- "," if not loop.last}} {%- endfor -%}]
             {%- if options is mapping -%}
             {%- for key, value in options.items() if key != 'uris' %}
-                , {{key}} = {{value}}
+                , {{key}} = '{{value}}'
             {%- endfor -%}
             {%- endif -%}
         )

--- a/macros/plugins/bigquery/create_external_table.sql
+++ b/macros/plugins/bigquery/create_external_table.sql
@@ -30,7 +30,11 @@
             uris = [{%- for uri in uris -%} '{{uri}}' {{- "," if not loop.last}} {%- endfor -%}]
             {%- if options is mapping -%}
             {%- for key, value in options.items() if key != 'uris' %}
+                {%- if value is string -%}
                 , {{key}} = '{{value}}'
+                {%- else -%}
+                , {{key}} = {{value}}
+                {%- endif -%}
             {%- endfor -%}
             {%- endif -%}
         )


### PR DESCRIPTION
## Description & motivation
Not tested this comprehensively but not wrapping `hive_partition_uri_prefix` in single quotes results in a syntax error and single quotes work fine for `format`. Should work for BOOL options and I _think_ it should work for timestamp values?

## Checklist
- [X] I have verified that these changes work locally