### PR TITLE
Wrap Snowflake DML in explicit transactions

### DIFF
--- a/macros/plugins/snowflake/refresh_external_table.sql
+++ b/macros/plugins/snowflake/refresh_external_table.sql
@@ -11,9 +11,9 @@
     {% if manual_refresh %}
 
         {% set ddl %}
-        BEGIN;
+        begin;
         alter external table {{source(source_node.source_name, source_node.name)}} refresh;
-        COMMIT;
+        commit;
         {% endset %}
         
         {% do return([ddl]) %}

--- a/macros/plugins/snowflake/snowpipe/get_copy_sql.sql
+++ b/macros/plugins/snowflake/snowpipe/get_copy_sql.sql
@@ -6,6 +6,7 @@
     {%- set is_csv = dbt_external_tables.is_csv(external.file_format) %}
     {%- set copy_options = external.snowpipe.get('copy_options', none) -%}
     
+    begin;
     copy into {{source(source_node.source_name, source_node.name)}}
     from ( 
         select
@@ -27,6 +28,7 @@
         from {{external.location}} {# stage #}
     )
     file_format = {{external.file_format}}
-    {% if copy_options %} {{copy_options}} {% endif %}
+    {% if copy_options %} {{copy_options}} {% endif %};
+    commit;
 
 {% endmacro %}


### PR DESCRIPTION
Follow-up to #95, #98

I haven't been able to get implicit transactions + `autocommit` to work to my liking. For now, just wrap DML statements in explicit `begin` + `commit`.

See also: https://github.com/fishtown-analytics/dbt/issues/3480

## Checklist
- [x] I have verified that these changes work locally
- ~I have updated the README.md (if applicable)~
- ~I have added an integration test for my fix/feature (if applicable)~
