### PR TITLE
feat(redshift): make partition vals optional for redshift external tables

### DIFF
--- a/integration_tests/models/plugins/redshift/redshift_external.yml
+++ b/integration_tests/models/plugins/redshift/redshift_external.yml
@@ -40,6 +40,16 @@ sources:
               path_macro: dbt_external_tables.key_value
         columns: *cols-of-the-people
         tests: *equal-to-the-people
+      
+      # partitioned but NO vals -> should create the table & skip partition DDL
+      - name: people_csv_partitioned_novals
+        external:
+          <<: *csv-people
+          partitions:
+            - name: section
+              data_type: varchar
+              path_macro: dbt_external_tables.key_value
+        columns: *cols-of-the-people
         
       # ensure that all partitions are created
       - name: people_csv_multipartitioned
@@ -87,3 +97,12 @@ sources:
           partitions: *parts-of-the-people
         columns: *cols-of-the-people
         tests: *equal-to-the-people
+
+      - name: people_json_partitioned_novals
+        external:
+          <<: *json-people
+          partitions:
+            - name: section
+              data_type: varchar
+              path_macro: dbt_external_tables.key_value
+        columns: *cols-of-the-people

--- a/macros/plugins/redshift/helpers/add_partitions.sql
+++ b/macros/plugins/redshift/helpers/add_partitions.sql
@@ -20,12 +20,12 @@
 #}
 {% macro redshift_alter_table_add_partitions(source_node, partitions) %}
 
-  {{ log("Generating ADD PARTITION statement for partition set between " 
-         ~ partitions[0]['path'] ~ " and " ~ (partitions|last)['path']) }}
-
   {% set ddl = [] %}
   
   {% if partitions|length > 0 %}
+
+    {{ log("Generating ADD PARTITION statement for partition set between " 
+           ~ partitions[0]['path'] ~ " and " ~ (partitions|last)['path']) }}
   
     {% set alter_table_add %}
         alter table {{source(source_node.source_name, source_node.name)}} add if not exists 

--- a/macros/plugins/redshift/refresh_external_table.sql
+++ b/macros/plugins/redshift/refresh_external_table.sql
@@ -4,6 +4,11 @@
 
     {%- if partitions -%}
     
+        {%- set missing = partitions | selectattr('vals','undefined') | list -%}
+        {%- if missing and (missing|length) > 0 -%}
+            {% do return([]) %}
+        {%- endif -%}
+    
         {%- set part_len = partitions|length -%}
     
         {%- set get_partitions_sql -%}


### PR DESCRIPTION
## Description & motivation
Redshift Spectrum doesn’t require partitions to be registered at table-create time. Many users register partitions later via Glue/Athena/event-driven flows. Forcing `vals` leads to brittle date math or references to partition values that do not exist, and it causes failures when `vals` are omitted.

**Changes**

- Make partition `vals` optional for Redshift during `stage_external_sources` .
- If every partition has `vals`, generate `ALTER TABLE … ADD PARTITION` (unchanged).
- If any partition lacks `vals`, skip only the partition-registration DDL; table creation and partition columns remain unchanged.

**User-visible behavior**

- Before: Missing `vals` → error (`'dict object' has no attribute 'vals'`).
- Now: Missing `vals` → succeeds; no partition DDL is emitted. Existing partitions remain unchanged.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [x] I have added an integration test for my fix/feature (if applicable)
