### PR TITLE
Pin GitHub Actions to specific SHAs (2 actions in 1 files)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -19,9 +19,9 @@ jobs:
         data-platform: ["redshift", "snowflake", "bigquery"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566  # actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dbt-${{ matrix.data-platform }}~=${{ matrix.dbt-version }}


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 1
- **Actions pinned**: 2

### 📝 Changes by file

#### `.github/workflows/integration_tests.yml`

- 📌 `actions/checkout@v3` → `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # actions/checkout@v3`
- 📌 `actions/setup-python@v3` → `actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566  # actions/setup-python@v3`

