### PR TITLE
Fix error in runs with --empty flag by adding .render()

### DIFF
--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -21,7 +21,7 @@
 {# This assumes you have already created an external stage #}
 
 {% set ddl %}
-    create or replace external table {{source(source_node.source_name, source_node.name)}}
+    create or replace external table {{source(source_node.source_name, source_node.name).render()}}
     {%- if columns or partitions or infer_schema -%}
     (
         {%- if partitions -%}{%- for partition in partitions %}

--- a/macros/plugins/snowflake/refresh_external_table.sql
+++ b/macros/plugins/snowflake/refresh_external_table.sql
@@ -13,7 +13,7 @@
 
         {% set ddl %}
         begin;
-        alter external table {{source(source_node.source_name, source_node.name)}} refresh;
+        alter external table {{source(source_node.source_name, source_node.name).render()}} refresh;
         commit;
         {% endset %}
         


### PR DESCRIPTION
## Description & motivation
The current code breaks for Snowflake when running `dbt run --empty`. Adding `.render()` to `source()` calls, as mentioned in [the official dbt docs](https://docs.getdbt.com/reference/commands/build#the-render-method), solves this problem.
Addresses issue https://github.com/dbt-labs/dbt-external-tables/issues/339 

## Checklist
- [x] I have verified that these changes work locally
