### PR TITLE
Drop external tables in CI so that stage and file format can be re-created

### DIFF
--- a/integration_tests/macros/plugins/snowflake/prep_external.sql
+++ b/integration_tests/macros/plugins/snowflake/prep_external.sql
@@ -6,6 +6,13 @@
     {% set create_external_stage_and_file_format %}
     
         begin;
+        drop external table if exists {{target.database}}.{{target.schema}}.people_parquet_column_list_ignore_case_partitioned;
+        drop external table if exists {{target.database}}.{{target.schema}}.people_parquet_column_list_partitioned;
+        drop external table if exists {{target.database}}.{{target.schema}}.people_parquet_column_list_unpartitioned;
+        drop external table if exists {{target.database}}.{{target.schema}}.people_parquet_infer_schema_ignore_case_unpartitioned;
+        drop external table if exists {{target.database}}.{{target.schema}}.people_parquet_infer_schema_partitioned;
+        drop external table if exists {{target.database}}.{{target.schema}}.people_parquet_infer_schema_partitioned_and_column_desc;
+        drop external table if exists {{target.database}}.{{target.schema}}.people_parquet_infer_schema_unpartitioned;
         create or replace stage
             {{ external_stage }}
             url = 's3://dbt-external-tables-testing';


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-external-tables/issues/376

## Problem

Getting an error during one of the steps of integration testing (`dbt1014` error when using Fusion) because the file format can not be dropped or replaced because it has active external table(s) using it.

## Solution

Drop all the external tables that were created during a previous CI run so that the file format can be replaced.

Normally, dropping tables like this could create data downtime if there were consumers relying upon them. But because these external tables are created just for CI (i.e., without consumers), we should be able to do this without creating problems.

## Checklist
- [X] I have verified that these changes work locally
- [X] ~I have updated the README.md (if applicable)~
- [X] ~I have added an integration test for my fix/feature (if applicable)~
