### PR TITLE
Fabric DWH - add support for creating views using OPENROWSET (BULK)

### DIFF
--- a/macros/plugins/fabric/create_external_table.sql
+++ b/macros/plugins/fabric/create_external_table.sql
@@ -1,31 +1,81 @@
 {% macro fabric__create_external_table(source_node) %}
 
     {%- set columns = source_node.columns.values() -%}
-    {%- set external = source_node.external -%}
+    {%- set external = source_node.external.get(target.type, source_node.external) -%}
 
     {% if external.ansi_nulls is true -%} SET ANSI_NULLS ON; {%- endif %}
     {% if external.quoted_identifier is true -%} SET QUOTED_IDENTIFIER ON; {%- endif %}
 
-    create external table {{source(source_node.source_name, source_node.name)}} (
-        {% for column in columns %}
-            {# TODO set nullity based on schema tests?? #}
-            {%- set nullity = 'NOT NULL' if 'not_null' in columns.tests else 'NULL'-%}
-            {{adapter.quote(column.name)}} {{column.data_type}} {{nullity}}
+    {% if target.type == 'synapse'%}
+
+        create external table {{source(source_node.source_name, source_node.name)}} (
+            {% for column in columns %}
+                {# TODO set nullity based on schema tests?? #}
+                {%- set nullity = 'NOT NULL' if 'not_null' in columns.tests else 'NULL'-%}
+                {{adapter.quote(column.name)}} {{column.data_type}} {{nullity}}
+                {{- ',' if not loop.last -}}
+            {% endfor %}
+        )
+        WITH (
+            {# remove keys that are None (i.e. not defined for a given source) #}
+            {%- for key, value in external.items() if value is not none and key not in ['ansi_nulls', 'quoted_identifier'] -%}
+                {{key}} = 
+                    {%- if key in ["location", "schema_name", "object_name"] -%}
+                        '{{value}}'
+                    {% elif key in ["data_source","file_format"] -%}
+                        [{{value}}]
+                    {% else -%}
+                        {{value}}
+                    {%- endif -%}
+                {{- ',' if not loop.last -}}
+                {%- endfor -%}
+        )
+
+    {% elif target.type == 'fabric'%}
+
+        {# These are ON by default. It is valid to set these off in Fabric DWH, but not in Synapse. #}
+        {% if external.ansi_nulls is false -%} SET ANSI_NULLS OFF; {%- endif %}
+        {% if external.quoted_identifier is false -%} SET QUOTED_IDENTIFIER OFF; {%- endif %}
+
+        create view {{source(source_node.source_name, source_node.name).include(database=false)}} as
+        select
+        {%- for column in columns %}
+            {{adapter.quote(column.name)}}
             {{- ',' if not loop.last -}}
         {% endfor %}
-    )
-    WITH (
-        {# remove keys that are None (i.e. not defined for a given source) #}
-        {%- for key, value in external.items() if value is not none and key not in ['ansi_nulls', 'quoted_identifier'] -%}
+        from
+        openrowset
+        (
+            {#- https://learn.microsoft.com/en-us/sql/t-sql/functions/openrowset-bulk-transact-sql?view=fabric #}
+            {#- BULK 'data_file_path', #}
+            {#- BULK '{{external.location}}{{'' if external.location.endswith('/') else '/'}}{{external.file_mask}}', -#}
+            BULK '{{external.location}}',
+            {%- for key, value in external.items() if value is not none and key not in ['location', 'use_column_ordinal', 'file_mask'] %}
             {{key}} = 
-                {%- if key in ["location", "schema_name", "object_name"] -%}
-                    '{{value}}'
-                {% elif key in ["data_source","file_format"] -%}
+                {%- if key in ['HEADER_ROW', 'MAXERRORS', 'FIRSTROW', 'LASTROW', 'ROWS_PER_BATCH'] -%}
+                {#%- if key in ["schema_name", "object_name", "FIELDTERMINATOR", "FIELDQUOTE", "ESCAPECHAR", "FORMAT", 'DATA_SOURCE','file_format'] -%#}
+                    {{- value}}
+                {# perhaps an options will require [] quoting?
+                {%- elif key in ['POSSIBLE_QUOTING_NEEDED'] -%}
                     [{{value}}]
-                {% else -%}
-                    {{value}}
+                #}
+                {%- else -%}
+                    '{{value}}'
                 {%- endif -%}
             {{- ',' if not loop.last -}}
-            {%- endfor -%}
-    )
+            {%- endfor %}
+        ) with (
+        {%- for column in columns %}
+            {% if external.use_column_ordinal is true -%}
+            {{adapter.quote(column.name)}} {{column.data_type}} {{loop.index}}{# {{nullity}} #}
+        {%- else -%}
+            {{adapter.quote(column.name)}} {{column.data_type}} {# {{nullity}} #}
+        {%- endif -%}
+            {{- ',' if not loop.last -}}
+        {% endfor %}
+        )
+
+    {% endif %}
+
+
 {% endmacro %}

--- a/macros/plugins/fabric/helpers/dropif.sql
+++ b/macros/plugins/fabric/helpers/dropif.sql
@@ -1,12 +1,25 @@
 {% macro fabric__dropif(node) %}
     
+  {% if target.type == 'synapse'%}
+
     {% set ddl %}
       if object_id ('{{source(node.source_name, node.name)}}') is not null
         begin
         drop external table {{source(node.source_name, node.name)}}
         end
     {% endset %}
+
+  {% elif target.type =='fabric' %}
+
+    {% set ddl %}
+      if object_id ('{{source(node.source_name, node.name)}}') is not null
+        begin
+        drop view {{source(node.source_name, node.name).include(database=false)}}
+        end
+    {% endset %}
+
+  {% endif %}
     
-    {{return(ddl)}}
+  {{return(ddl)}}
 
 {% endmacro %}

--- a/sample_sources/fabric.yml
+++ b/sample_sources/fabric.yml
@@ -1,0 +1,126 @@
+version: 2
+
+sources:
+  - name: marketo
+    schema: source_marketo
+    loader: ADLSblob
+    tables:
+      - name: lead_activities
+        description: |
+          from raw DW.
+        external:          
+          # Ending location with `**` will recurse through subfolders
+          location: /marketing/Marketo/LeadActivities/**
+          # Optional. When `true`, the WITH clause will include the column ordinal based on the source.yml. Default is `false`.
+          # Setting this option overrides matching columns by name.
+          use_column_ordinal: true
+          ## OPENROWSET <bulk_options>: https://learn.microsoft.com/en-us/sql/t-sql/functions/openrowset-bulk-transact-sql?view=fabric
+          DATA_SOURCE:  MY_DATA_SOURCE
+          FORMAT:  CSV
+          FIELDTERMINATOR: '|'
+          FIELDQUOTE: ''
+          ESCAPECHAR: \
+          HEADER_ROW: 'TRUE'
+          CODEPAGE: 
+          DATAFILETYPE:
+          PARSER_VERSION:
+          MAXERRORS:
+          ERRORFILE:
+          FIRSTROW:
+          LASTROW:
+          ROWS_PER_BATCH:
+        columns:
+          - name: id
+            description: unique Activity ID
+            data_type: int
+          - name: leadId
+            description: Lead ID
+            data_type: int
+          - name: activityDate
+            description: date of activity
+            data_type: varchar(255)
+          - name: activityTypeId
+            description: unique identifier for type of activity
+            data_type: int
+          - name: campaignId
+            description: Campaign under which activity took place
+            data_type: int
+          - name: primaryAttributeValueId
+            description: the main attribute for given activity type
+            data_type: int
+          - name: primaryAttributeValue
+            description: what value was taken
+            data_type: varchar(255)
+
+# Generated SQL with `use_column_ordinal = false` (default):
+#
+# create view "source_marketo"."lead_activities" as
+# select
+#     "id",
+#     "leadId",
+#     "activityDate",
+#     "activityTypeId",
+#     "campaignId",
+#     "primaryAttributeValueId",
+#     "primaryAttributeValue"
+# from
+# openrowset
+# (BULK '/marketing/Marketo/LeadActivities/**',
+#     DATA_SOURCE ='MY_DATA_SOURCE',
+#     FORMAT ='CSV',
+#     FIELDTERMINATOR ='|',
+#     FIELDQUOTE ='',
+#     ESCAPECHAR ='\',
+#     HEADER_ROW =TRUE
+#         
+# ) with (
+#     "id" int ,
+#     "leadId" int ,
+#     "activityDate" varchar(255) ,
+#     "activityTypeId" int ,
+#     "campaignId" int ,
+#     "primaryAttributeValueId" int ,
+#     "primaryAttributeValue" varchar(255) 
+# )
+
+# Generated SQL with `use_column_ordinal = true `:
+#
+# create view "source_marketo"."lead_activities" as
+# select
+#     "id",
+#     "leadId",
+#     "activityDate",
+#     "activityTypeId",
+#     "campaignId",
+#     "primaryAttributeValueId",
+#     "primaryAttributeValue"
+# from
+# openrowset
+# (BULK '/marketing/Marketo/LeadActivities/**',
+#     DATA_SOURCE ='MY_DATA_SOURCE',
+#     FORMAT ='CSV',
+#     FIELDTERMINATOR ='|',
+#     FIELDQUOTE ='',
+#     ESCAPECHAR ='\',
+#     HEADER_ROW =TRUE
+#         
+# ) with (
+#     "id" int 1,
+#     "leadId" int 2,
+#     "activityDate" varchar(255) 3,
+#     "activityTypeId" int 4,
+#     "campaignId" int 5,
+#     "primaryAttributeValueId" int 6,
+#     "primaryAttributeValue" varchar(255) 7
+# )
+
+# If you're working with both Synapse and Fabric, you may specify a configuration section for each.
+# Insert an additional section under `external` using `target.type`. E.g.:
+# 
+#   external:
+#     synapse:
+#       <existing synapse external table config>
+#     fabric:
+#       <new fabric external table config>
+#
+# `target.type`-specific configurations take precedence over the generic `external` configuration.


### PR DESCRIPTION
This PR adds the ability to create views that leverage `OPENROWSET (BULK)` to provide an external table equivalent in Fabric DWH. 

Also adds support for specifying a configuration for both Synapse and Fabric in the same file for projects that need to interact with both platforms.